### PR TITLE
Add new functions to slim tensor

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1341,6 +1341,7 @@ if(BUILD_TEST)
   else()
     add_subdirectory(${TORCH_ROOT}/test/cpp/jit ${CMAKE_BINARY_DIR}/test_jit)
     add_subdirectory(${TORCH_ROOT}/test/cpp/nativert ${CMAKE_BINARY_DIR}/test_nativert)
+    add_subdirectory(${TORCH_ROOT}/test/cpp/aoti_standalone ${CMAKE_BINARY_DIR}/test_aoti_standalone)
     add_subdirectory(${TORCH_ROOT}/test/inductor ${CMAKE_BINARY_DIR}/test_inductor)
     add_subdirectory(
       ${TORCH_ROOT}/test/cpp/tensorexpr

--- a/test/cpp/aoti_standalone/CMakeLists.txt
+++ b/test/cpp/aoti_standalone/CMakeLists.txt
@@ -11,13 +11,6 @@ add_executable(test_aoti_standalone
 # TODO temporary until we can delete the old gtest polyfills.
 target_compile_definitions(test_aoti_standalone PRIVATE USE_GTEST)
 
-# Define a custom command to generate the library
-add_custom_command(
-        OUTPUT data.pt
-        COMMAND python ${AOT_INDUCTOR_TEST_ROOT}/test.py
-        DEPENDS ${AOT_INDUCTOR_TEST_ROOT}/test.py
-)
-
 target_link_libraries(test_aoti_standalone PRIVATE
   torch
   gtest_main

--- a/test/cpp/aoti_standalone/CMakeLists.txt
+++ b/test/cpp/aoti_standalone/CMakeLists.txt
@@ -1,0 +1,43 @@
+
+set(AOTI_STANDALONE_TEST_ROOT ${TORCH_ROOT}/test/cpp/aoti_standalone)
+
+file(GLOB_RECURSE AOTI_STANDALONE_TEST_SRCS "${AOTI_STANDALONE_TEST_ROOT}/test*.cpp")
+
+add_executable(test_aoti_standalone
+  ${TORCH_ROOT}/test/cpp/common/main.cpp
+  ${AOTI_STANDALONE_TEST_SRCS}
+)
+
+# TODO temporary until we can delete the old gtest polyfills.
+target_compile_definitions(test_aoti_standalone PRIVATE USE_GTEST)
+
+# Define a custom command to generate the library
+add_custom_command(
+        OUTPUT data.pt
+        COMMAND python ${AOT_INDUCTOR_TEST_ROOT}/test.py
+        DEPENDS ${AOT_INDUCTOR_TEST_ROOT}/test.py
+)
+
+target_link_libraries(test_aoti_standalone PRIVATE
+  torch
+  gtest_main
+)
+
+if(USE_CUDA)
+  target_include_directories(test_aoti_standalone PRIVATE ${ATen_CUDA_INCLUDE})
+  target_compile_definitions(test_aoti_standalone PRIVATE USE_CUDA)
+elseif(USE_ROCM)
+    target_include_directories(test_aoti_standalone PRIVATE ${ATen_HIP_INCLUDE})
+    target_compile_definitions(test_aoti_standalone PRIVATE USE_ROCM)
+endif()
+target_compile_definitions(test_aoti_standalone PRIVATE
+    CMAKE_CURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
+)
+
+if(INSTALL_TEST)
+  install(TARGETS test_aoti_standalone DESTINATION bin)
+  # Install PDB files for MSVC builds
+  if(MSVC AND BUILD_SHARED_LIBS)
+    install(FILES $<TARGET_PDB_FILE:test_aoti_standalone> DESTINATION bin OPTIONAL)
+  endif()
+endif()

--- a/test/cpp/aoti_standalone/test_slim_tensor.cpp
+++ b/test/cpp/aoti_standalone/test_slim_tensor.cpp
@@ -2,82 +2,76 @@
 #include <gtest/gtest.h>
 
 #include <c10/core/MemoryFormat.h>
-#include <torch/standalone/slim_tensor/slim_tensor.h>
-#include <torch/standalone/slim_tensor/array_ref.h>
 #include <torch/csrc/inductor/aoti_standalone/factory.h>
+#include <torch/standalone/slim_tensor/array_ref.h>
+#include <torch/standalone/slim_tensor/slim_tensor.h>
 
 namespace torch::standalone {
 
 using ::testing::ElementsAreArray;
 
 TEST(SlimTensorInternalTest, SetSizesContiguous) {
-    SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
-    EXPECT_EQ(tensor.numel(), 1);
+  SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
+  EXPECT_EQ(tensor.numel(), 1);
 
-    std::vector<int64_t> new_size_vec = {2, 3, 4};
-    ArrayRef new_sizes(new_size_vec.data(), new_size_vec.size());
-    tensor.set_sizes_contiguous(new_sizes);
+  std::vector<int64_t> new_size_vec = {2, 3, 4};
+  ArrayRef new_sizes(new_size_vec.data(), new_size_vec.size());
+  tensor.set_sizes_contiguous(new_sizes);
 
-    //
-    EXPECT_EQ(tensor.dim(), 3);
-    EXPECT_EQ(tensor.numel(), 24);
+  EXPECT_EQ(tensor.dim(), 3);
+  EXPECT_EQ(tensor.numel(), 24);
 
-    EXPECT_THAT(tensor.sizes(), ElementsAreArray({2, 3, 4}));
-    EXPECT_THAT(tensor.strides(), ElementsAreArray({12, 4, 1}));
-    EXPECT_TRUE(tensor.is_contiguous());
-
+  EXPECT_THAT(tensor.sizes(), ElementsAreArray({2, 3, 4}));
+  EXPECT_THAT(tensor.strides(), ElementsAreArray({12, 4, 1}));
+  EXPECT_TRUE(tensor.is_contiguous());
 }
 
-
 TEST(SlimTensorInternalTest, SetSizesAndStridesNonContiguous) {
+  SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
 
-    SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
+  // Set sizes and strides to represent a transposed tensor.
+  // This is equivalent to a (2, 4) tensor that has been transposed to (4, 2).
+  std::vector<int64_t> new_size_vec = {4, 2};
 
-    // Set sizes and strides to represent a transposed tensor.
-    // This is equivalent to a (2, 4) tensor that has been transposed to (4, 2).
-    std::vector<int64_t> new_size_vec = {4, 2};
+  // Strides of original (2, 4) were {4, 1}
+  std::vector<int64_t> new_stride_vec = {1, 4};
+  ArrayRef new_sizes(new_size_vec.data(), new_size_vec.size());
+  ArrayRef new_strides(new_stride_vec.data(), new_stride_vec.size());
 
-    // Strides of original (2, 4) were {4, 1}
-    std::vector<int64_t> new_stride_vec = {1, 4};
-    ArrayRef new_sizes(new_size_vec.data(), new_size_vec.size());
-    ArrayRef new_strides(new_stride_vec.data(), new_stride_vec.size());
+  tensor.set_sizes_and_strides(new_sizes, new_strides);
 
-    tensor.set_sizes_and_strides(new_sizes, new_strides);
+  // verify
+  EXPECT_EQ(tensor.dim(), 2);
+  EXPECT_EQ(tensor.numel(), 8);
+  EXPECT_THAT(tensor.sizes(), ElementsAreArray({4, 2}));
+  EXPECT_THAT(tensor.strides(), ElementsAreArray({1, 4}));
 
-    // verify
-    EXPECT_EQ(tensor.dim(), 2);
-    EXPECT_EQ(tensor.numel(), 8);
-    EXPECT_THAT(tensor.sizes(), ElementsAreArray({4, 2}));
-    EXPECT_THAT(tensor.strides(), ElementsAreArray({1, 4}));
-
-    // A transposed tensor is not contiguous.
-    EXPECT_FALSE(tensor.is_contiguous());
+  // A transposed tensor is not contiguous.
+  EXPECT_FALSE(tensor.is_contiguous());
 }
 
 TEST(SlimTensorInternalTest, EmptyTensorRestride) {
-    SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
-    std::vector<int64_t> size_vec = {4, 2};
-    std::vector<int64_t> stride_vec = {1, 4}; // Non-contiguous strides
-    tensor.set_sizes_and_strides(
-        ArrayRef(size_vec.data(), size_vec.size()),
-        ArrayRef(stride_vec.data(), stride_vec.size())
-    );
-    // it shouldn't be contiguous first
-    EXPECT_FALSE(tensor.is_contiguous());
+  SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
+  std::vector<int64_t> size_vec = {4, 2};
+  std::vector<int64_t> stride_vec = {1, 4}; // Non-contiguous strides
+  tensor.set_sizes_and_strides(
+      ArrayRef(size_vec.data(), size_vec.size()),
+      ArrayRef(stride_vec.data(), stride_vec.size()));
+  // it shouldn't be contiguous first
+  EXPECT_FALSE(tensor.is_contiguous());
 
-    // make the tensor contiguous.
-    tensor.empty_tensor_restride(c10::MemoryFormat::Contiguous);
+  // make the tensor contiguous.
+  tensor.empty_tensor_restride(c10::MemoryFormat::Contiguous);
 
-    // Sizes should NOT have changed.
-    EXPECT_EQ(tensor.dim(), 2);
-    EXPECT_THAT(tensor.sizes(), ElementsAreArray({4, 2}));
+  // Sizes should NOT have changed.
+  EXPECT_EQ(tensor.dim(), 2);
+  EXPECT_THAT(tensor.sizes(), ElementsAreArray({4, 2}));
 
-    // Strides SHOULD have changed to be contiguous for a (4, 2) tensor.
-    EXPECT_THAT(tensor.strides(), ElementsAreArray({2, 1}));
+  // Strides SHOULD have changed to be contiguous for a (4, 2) tensor.
+  EXPECT_THAT(tensor.strides(), ElementsAreArray({2, 1}));
 
-    // The contiguity flag should now be true.
-    EXPECT_TRUE(tensor.is_contiguous());
-
+  // The contiguity flag should now be true.
+  EXPECT_TRUE(tensor.is_contiguous());
 }
 
 } // namespace torch::standalone

--- a/test/cpp/aoti_standalone/test_slim_tensor.cpp
+++ b/test/cpp/aoti_standalone/test_slim_tensor.cpp
@@ -1,7 +1,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <torch/torch.h> // For c10::MemoryFormat
+#include <c10/core/MemoryFormat.h>
 #include <torch/standalone/slim_tensor/slim_tensor.h>
 #include <torch/standalone/slim_tensor/array_ref.h>
 #include <torch/csrc/inductor/aoti_standalone/factory.h>

--- a/test/cpp/aoti_standalone/test_slim_tensor.cpp
+++ b/test/cpp/aoti_standalone/test_slim_tensor.cpp
@@ -1,0 +1,83 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <torch/torch.h> // For c10::MemoryFormat
+#include <torch/standalone/slim_tensor/slim_tensor.h>
+#include <torch/standalone/slim_tensor/array_ref.h>
+#include <torch/csrc/inductor/aoti_standalone/factory.h>
+
+namespace torch::standalone {
+
+using ::testing::ElementsAreArray;
+
+TEST(SlimTensorInternalTest, SetSizesContiguous) {
+    SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
+    EXPECT_EQ(tensor.numel(), 1);
+
+    std::vector<int64_t> new_size_vec = {2, 3, 4};
+    ArrayRef new_sizes(new_size_vec.data(), new_size_vec.size());
+    tensor.set_sizes_contiguous(new_sizes);
+
+    //
+    EXPECT_EQ(tensor.dim(), 3);
+    EXPECT_EQ(tensor.numel(), 24);
+
+    EXPECT_THAT(tensor.sizes(), ElementsAreArray({2, 3, 4}));
+    EXPECT_THAT(tensor.strides(), ElementsAreArray({12, 4, 1}));
+    EXPECT_TRUE(tensor.is_contiguous());
+
+}
+
+
+TEST(SlimTensorInternalTest, SetSizesAndStridesNonContiguous) {
+
+    SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
+
+    // Set sizes and strides to represent a transposed tensor.
+    // This is equivalent to a (2, 4) tensor that has been transposed to (4, 2).
+    std::vector<int64_t> new_size_vec = {4, 2};
+
+    // Strides of original (2, 4) were {4, 1}
+    std::vector<int64_t> new_stride_vec = {1, 4};
+    ArrayRef new_sizes(new_size_vec.data(), new_size_vec.size());
+    ArrayRef new_strides(new_stride_vec.data(), new_stride_vec.size());
+
+    tensor.set_sizes_and_strides(new_sizes, new_strides);
+
+    // verify
+    EXPECT_EQ(tensor.dim(), 2);
+    EXPECT_EQ(tensor.numel(), 8);
+    EXPECT_THAT(tensor.sizes(), ElementsAreArray({4, 2}));
+    EXPECT_THAT(tensor.strides(), ElementsAreArray({1, 4}));
+
+    // A transposed tensor is not contiguous.
+    EXPECT_FALSE(tensor.is_contiguous());
+}
+
+TEST(SlimTensorInternalTest, EmptyTensorRestride) {
+    SlimTensor tensor = create_empty_tensor({}, {}, c10::kFloat);
+    std::vector<int64_t> size_vec = {4, 2};
+    std::vector<int64_t> stride_vec = {1, 4}; // Non-contiguous strides
+    tensor.set_sizes_and_strides(
+        ArrayRef(size_vec.data(), size_vec.size()),
+        ArrayRef(stride_vec.data(), stride_vec.size())
+    );
+    // it shouldn't be contiguous first
+    EXPECT_FALSE(tensor.is_contiguous());
+
+    // make the tensor contiguous.
+    tensor.empty_tensor_restride(c10::MemoryFormat::Contiguous);
+
+    // Sizes should NOT have changed.
+    EXPECT_EQ(tensor.dim(), 2);
+    EXPECT_THAT(tensor.sizes(), ElementsAreArray({4, 2}));
+
+    // Strides SHOULD have changed to be contiguous for a (4, 2) tensor.
+    EXPECT_THAT(tensor.strides(), ElementsAreArray({2, 1}));
+
+    // The contiguity flag should now be true.
+    EXPECT_TRUE(tensor.is_contiguous());
+
+}
+
+} // namespace torch::standalone

--- a/torch/csrc/inductor/aoti_standalone/utils.h
+++ b/torch/csrc/inductor/aoti_standalone/utils.h
@@ -27,6 +27,7 @@ using AOTITorchError = int32_t;
   }                                                       \
   return AOTI_TORCH_SUCCESS;
 
+namespace torch::standalone {
 inline int64_t maybe_wrap_dim(int64_t dim, int64_t ndim) {
   if (dim < 0) {
     dim += ndim;
@@ -36,3 +37,5 @@ inline int64_t maybe_wrap_dim(int64_t dim, int64_t ndim) {
   }
   return dim;
 }
+
+} // namespace torch::standalone

--- a/torch/standalone/slim_tensor/array_ref.h
+++ b/torch/standalone/slim_tensor/array_ref.h
@@ -12,6 +12,7 @@ namespace torch::standalone {
 template <typename T>
 class MaybeOwningArrayRef final {
  public:
+  using value_type = T;
   using iterator = T*;
   using const_iterator = const T*;
   using reverse_iterator = std::reverse_iterator<iterator>;

--- a/torch/standalone/slim_tensor/array_ref.h
+++ b/torch/standalone/slim_tensor/array_ref.h
@@ -208,4 +208,14 @@ class MaybeOwningArrayRef final {
 
 using ArrayRef = MaybeOwningArrayRef<const int64_t>;
 
+template <typename T>
+inline bool operator==(
+    const MaybeOwningArrayRef<T>& lhs,
+    const MaybeOwningArrayRef<T>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
+
 } // namespace torch::standalone

--- a/torch/standalone/slim_tensor/slim_tensor.h
+++ b/torch/standalone/slim_tensor/slim_tensor.h
@@ -102,6 +102,10 @@ class SlimTensor {
     return is_contiguous_;
   }
 
+  void set_storage(Storage&& new_storage) {
+    storage_ = std::move(new_storage);
+  }
+
   void set_sizes_and_strides(
       const ArrayRef& sizes,
       const ArrayRef& strides,

--- a/torch/standalone/slim_tensor/slim_tensor.h
+++ b/torch/standalone/slim_tensor/slim_tensor.h
@@ -224,13 +224,8 @@ class SlimTensor {
     throw std::runtime_error("TBD: to(dtype)");
   }
 
-<<<<<<< HEAD
-  SlimTensor permute(const ArrayRef& dims) const {
-    const int64_t ndim = this->dim();
-=======
   SlimTensor permute(ArrayRef dims) const {
     const int64_t ndim = static_cast<int64_t>(this->dim());
->>>>>>> 22c1a63f845 (add member functions for slim tensor)
 
     TORCH_CHECK(
         ndim == static_cast<int64_t>(dims.size()),
@@ -256,10 +251,6 @@ class SlimTensor {
         ArrayRef(new_sizes.data(), ndim, /*owning=*/true),
         ArrayRef(new_strides.data(), ndim, /*owning=*/true),
         this->storage_offset());
-<<<<<<< HEAD
-=======
-
->>>>>>> 22c1a63f845 (add member functions for slim tensor)
     return result;
   }
 

--- a/torch/standalone/slim_tensor/utils.h
+++ b/torch/standalone/slim_tensor/utils.h
@@ -67,33 +67,33 @@ inline size_t compute_nbytes(size_t numel, c10::ScalarType dtype) {
 }
 
 inline int64_t compute_storage_nbytes_contiguous(
-  ArrayRef sizes,
-  size_t itemsize,
-  int64_t storage_offset) {
-int64_t numel = 1;
-for (auto s : sizes) {
-  numel *= s;
-}
-return static_cast<int64_t>(itemsize) * (storage_offset + numel);
+    ArrayRef sizes,
+    size_t itemsize,
+    int64_t storage_offset) {
+  int64_t numel = 1;
+  for (auto s : sizes) {
+    numel *= s;
+  }
+  return static_cast<int64_t>(itemsize) * (storage_offset + numel);
 }
 
 inline int64_t compute_storage_nbytes(
-  ArrayRef sizes,
-  ArrayRef strides,
-  size_t itemsize,
-  int64_t storage_offset) {
-if (sizes.empty()) {
-  return static_cast<int64_t>(itemsize) * storage_offset;
-}
-
-int64_t size = 1;
-for (size_t i = 0; i < sizes.size(); i++) {
-  if (sizes[i] == 0) {
-    return 0;
+    ArrayRef sizes,
+    ArrayRef strides,
+    size_t itemsize,
+    int64_t storage_offset) {
+  if (sizes.empty()) {
+    return static_cast<int64_t>(itemsize) * storage_offset;
   }
-  size += strides[i] * (sizes[i] - 1);
-}
-return static_cast<int64_t>(itemsize) * (storage_offset + size);
+
+  int64_t size = 1;
+  for (size_t i = 0; i < sizes.size(); i++) {
+    if (sizes[i] == 0) {
+      return 0;
+    }
+    size += strides[i] * (sizes[i] - 1);
+  }
+  return static_cast<int64_t>(itemsize) * (storage_offset + size);
 }
 
 } // namespace torch::standalone

--- a/torch/standalone/slim_tensor/utils.h
+++ b/torch/standalone/slim_tensor/utils.h
@@ -66,4 +66,34 @@ inline size_t compute_nbytes(size_t numel, c10::ScalarType dtype) {
 #endif
 }
 
+inline int64_t compute_storage_nbytes_contiguous(
+  ArrayRef sizes,
+  size_t itemsize,
+  int64_t storage_offset) {
+int64_t numel = 1;
+for (auto s : sizes) {
+  numel *= s;
+}
+return static_cast<int64_t>(itemsize) * (storage_offset + numel);
+}
+
+inline int64_t compute_storage_nbytes(
+  ArrayRef sizes,
+  ArrayRef strides,
+  size_t itemsize,
+  int64_t storage_offset) {
+if (sizes.empty()) {
+  return static_cast<int64_t>(itemsize) * storage_offset;
+}
+
+int64_t size = 1;
+for (size_t i = 0; i < sizes.size(); i++) {
+  if (sizes[i] == 0) {
+    return 0;
+  }
+  size += strides[i] * (sizes[i] - 1);
+}
+return static_cast<int64_t>(itemsize) * (storage_offset + size);
+}
+
 } // namespace torch::standalone


### PR DESCRIPTION
## Context
I am implementing standalone shim versions of all the necessary operators for running the Whisper Model libtorch-free, thereby eliminating the dependency on ATen. This PR is related with `resize_` operator.
[Enabling TorchNative Standalone on Whisper](https://docs.google.com/document/d/1BOdW0MA6n8couHc24s32np4qRkED1F3QZteWgNitaUY/edit?usp=sharing)

## Summary
When I was implementing [resize_](https://www.internalfb.com/code/fbsource/[f8181402352b][details]/fbcode/caffe2/aten/src/ATen/native/Resize.cpp?lines=261) operator, I've seen that the ATen tensor that is passed to resize has some member functions and we also need to add them to our `SlimTensor`.

In order for code reviewer to be able to compare the functions I wrote easily, I will map every function to its aten implementation. I've paid close attention to stick with the same structure (like using the same function names and dividing the methods into the similar functions etcc.)

These member functions are:
- empty_tensor_restride()
    - [aten implementation](https://www.internalfb.com/code/fbsource/[f8181402352b][details]/fbcode/caffe2/c10/core/TensorImpl.h?lines=2378) 
- set_sizes_contiguous()
    - [aten implementation ](https://www.internalfb.com/code/fbsource/[f8181402352b][details]/fbcode/caffe2/c10/core/TensorImpl.h?lines=1822)
- set_sizes_and_strides()
    - [aten implementation](https://www.internalfb.com/code/fbsource/[f8181402352b][details]/fbcode/caffe2/c10/core/TensorImpl.cpp?lines=846) 
- resize_bytes_cpu()
    - [aten implementation](https://www.internalfb.com/code/fbsource/[f8181402352b][details]/fbcode/caffe2/aten/src/ATen/native/Resize.cpp?lines=93)
   

## Changes in other files:

`array_ref.h`:
    - I had to add `using value_type = T` in `array_ref.h` to make our test run. I was getting an error there so I had to include it.
    - Also to be able to compare two ArrayRefs I added an '==' operator.
- I added CMakeLists.txt in test/cpp/aoti_standalone and added a line to caffe2/CMakeLists.txt for it to see the file I added
- Created test_slim_tensor.cpp file insdie test/cpp/aoti_standalone


## Testing

I have created a test for all three functions.
Run `./build/bin/test_aoti_standalone`

```
(pytorch-3.12) [serhatgundem@devvm2480.eag0 /data/users/serhatgundem/pytorch_fork (add_new_functions_to_slim_tensor)]$ ./build/bin/test_aoti_standalone
Only one CUDA device detected. Disabling MultiCUDA tests
Note: Google Test filter = *-*_MultiCUDA
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from SlimTensorInternalTest
[ RUN      ] SlimTensorInternalTest.SetSizesContiguous
[       OK ] SlimTensorInternalTest.SetSizesContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.SetSizesAndStridesNonContiguous
[       OK ] SlimTensorInternalTest.SetSizesAndStridesNonContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.EmptyTensorRestride
[       OK ] SlimTensorInternalTest.EmptyTensorRestride (0 ms)
[----------] 3 tests from SlimTensorInternalTest (0 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.
```


## Next Steps:
- For now we only use MemoryFormat::Contiguous in `empty_tensor_restride()` but we need to handle the other memory formats


<img width="1083" alt="Screenshot 2025-06-18 at 2 38 41 PM" src="https://github.com/user-attachments/assets/1d403999-1680-4e3d-bc8f-1e7333593fe3" />
