### PR TITLE
fix copying from non-contiguous tensor issue

### DIFF
--- a/test/cpp/aoti_standalone/test_slim_tensor.cpp
+++ b/test/cpp/aoti_standalone/test_slim_tensor.cpp
@@ -78,9 +78,8 @@ TEST(SlimTensorInternalTest, EmptyTensorRestride) {
 TEST(SlimTensorInternalTest, CopyFromContiguous) {
   // Create a contiguous source tensor.
   std::vector<float> src_data = {0, 1, 2, 3, 4, 5, 6, 7};
-  SlimTensor src_tensor =
-      torch::standalone::create_tensor_from_blob(
-          src_data.data(), {2, 4}, {4, 1}, c10::kFloat);
+  SlimTensor src_tensor = torch::standalone::create_tensor_from_blob(
+      src_data.data(), {2, 4}, {4, 1}, c10::kFloat);
   ASSERT_TRUE(src_tensor.is_contiguous());
 
   // Create an empty, contiguous destination tensor.
@@ -106,9 +105,8 @@ TEST(SlimTensorInternalTest, CopyFromNonContiguous) {
   // This simulates a (2, 4) tensor with data [0, 1, 2, 3, 4, 5, 6, 7]
   // that has been transposed to (4, 2).
   std::vector<float> src_data = {0, 1, 2, 3, 4, 5, 6, 7};
-  SlimTensor src_tensor =
-      torch::standalone::create_tensor_from_blob(
-          src_data.data(), {4, 2}, {1, 4}, c10::kFloat);
+  SlimTensor src_tensor = torch::standalone::create_tensor_from_blob(
+      src_data.data(), {4, 2}, {1, 4}, c10::kFloat);
   ASSERT_FALSE(src_tensor.is_contiguous());
 
   // Create an empty, contiguous destination tensor of the same shape.

--- a/test/cpp/aoti_standalone/test_slim_tensor.cpp
+++ b/test/cpp/aoti_standalone/test_slim_tensor.cpp
@@ -6,9 +6,10 @@
 #include <torch/standalone/slim_tensor/slim_tensor.h>
 
 using ::testing::ElementsAreArray;
+using torch::standalone::SlimTensor;
 
 TEST(SlimTensorInternalTest, SetSizesContiguous) {
-  torch::standalone::SlimTensor tensor =
+  SlimTensor tensor =
       torch::standalone::create_empty_tensor({}, {}, c10::kFloat);
   EXPECT_EQ(tensor.numel(), 1);
 
@@ -25,7 +26,7 @@ TEST(SlimTensorInternalTest, SetSizesContiguous) {
 }
 
 TEST(SlimTensorInternalTest, SetSizesAndStridesNonContiguous) {
-  torch::standalone::SlimTensor tensor =
+  SlimTensor tensor =
       torch::standalone::create_empty_tensor({}, {}, c10::kFloat);
 
   // Set sizes and strides to represent a transposed tensor.
@@ -50,7 +51,7 @@ TEST(SlimTensorInternalTest, SetSizesAndStridesNonContiguous) {
 }
 
 TEST(SlimTensorInternalTest, EmptyTensorRestride) {
-  torch::standalone::SlimTensor tensor =
+  SlimTensor tensor =
       torch::standalone::create_empty_tensor({}, {}, c10::kFloat);
   std::vector<int64_t> size_vec = {4, 2};
   std::vector<int64_t> stride_vec = {1, 4}; // Non-contiguous strides
@@ -77,14 +78,14 @@ TEST(SlimTensorInternalTest, EmptyTensorRestride) {
 TEST(SlimTensorInternalTest, CopyFromContiguous) {
   // Create a contiguous source tensor.
   std::vector<float> src_data = {0, 1, 2, 3, 4, 5, 6, 7};
-  torch::standalone::SlimTensor src_tensor =
+  SlimTensor src_tensor =
       torch::standalone::create_tensor_from_blob(
           src_data.data(), {2, 4}, {4, 1}, c10::kFloat);
   ASSERT_TRUE(src_tensor.is_contiguous());
 
   // Create an empty, contiguous destination tensor.
   std::vector<int64_t> dst_strides = {4, 1};
-  torch::standalone::SlimTensor dst_tensor =
+  SlimTensor dst_tensor =
       torch::standalone::create_empty_tensor({2, 4}, dst_strides, c10::kFloat);
   ASSERT_TRUE(dst_tensor.is_contiguous());
 
@@ -105,14 +106,14 @@ TEST(SlimTensorInternalTest, CopyFromNonContiguous) {
   // This simulates a (2, 4) tensor with data [0, 1, 2, 3, 4, 5, 6, 7]
   // that has been transposed to (4, 2).
   std::vector<float> src_data = {0, 1, 2, 3, 4, 5, 6, 7};
-  torch::standalone::SlimTensor src_tensor =
+  SlimTensor src_tensor =
       torch::standalone::create_tensor_from_blob(
           src_data.data(), {4, 2}, {1, 4}, c10::kFloat);
   ASSERT_FALSE(src_tensor.is_contiguous());
 
   // Create an empty, contiguous destination tensor of the same shape.
   std::vector<int64_t> dst_strides = {2, 1};
-  torch::standalone::SlimTensor dst_tensor =
+  SlimTensor dst_tensor =
       torch::standalone::create_empty_tensor({4, 2}, dst_strides, c10::kFloat);
   ASSERT_TRUE(dst_tensor.is_contiguous());
 

--- a/torch/standalone/slim_tensor/utils.h
+++ b/torch/standalone/slim_tensor/utils.h
@@ -149,40 +149,4 @@ inline int64_t compute_storage_nbytes(
 #endif
 }
 
-template <typename scalar_t>
-void elementwise_copy(
-    scalar_t* dst_data,
-    const scalar_t* src_data,
-    size_t numel,
-    size_t ndim,
-    c10::IntArrayRef sizes,
-    c10::IntArrayRef src_strides) {
-  if (numel == 0) {
-    return;
-  }
-
-  std::vector<int64_t> counter(ndim, 0);
-  for (size_t i = 0; i < numel; i++) {
-    int64_t src_offset = 0;
-    for (size_t d = 0; d < ndim; d++) {
-      src_offset += counter[d] * src_strides[d];
-    }
-
-    // the destination is contiguous so its offset is simply the element index
-    // 'i'.
-    dst_data[i] = src_data[src_offset];
-
-    // increment the multi-dimensional counter to find the next logical element
-    int64_t current_dim = static_cast<int64_t>(ndim) - 1;
-    while (current_dim >= 0) {
-      counter[current_dim]++;
-      if (counter[current_dim] < sizes[current_dim]) {
-        break;
-      }
-      counter[current_dim] = 0;
-      current_dim--;
-    }
-  }
-}
-
 } // namespace torch::standalone

--- a/torch/standalone/slim_tensor/utils.h
+++ b/torch/standalone/slim_tensor/utils.h
@@ -149,4 +149,40 @@ inline int64_t compute_storage_nbytes(
 #endif
 }
 
+template <typename scalar_t>
+void elementwise_copy(
+    scalar_t* dst_data,
+    const scalar_t* src_data,
+    size_t numel,
+    size_t ndim,
+    c10::IntArrayRef sizes,
+    c10::IntArrayRef src_strides) {
+  if (numel == 0) {
+    return;
+  }
+
+  std::vector<int64_t> counter(ndim, 0);
+  for (size_t i = 0; i < numel; i++) {
+    int64_t src_offset = 0;
+    for (size_t d = 0; d < ndim; d++) {
+      src_offset += counter[d] * src_strides[d];
+    }
+
+    // the destination is contiguous so its offset is simply the element index
+    // 'i'.
+    dst_data[i] = src_data[src_offset];
+
+    // increment the multi-dimensional counter to find the next logical element
+    int64_t current_dim = static_cast<int64_t>(ndim) - 1;
+    while (current_dim >= 0) {
+      counter[current_dim]++;
+      if (counter[current_dim] < sizes[current_dim]) {
+        break;
+      }
+      counter[current_dim] = 0;
+      current_dim--;
+    }
+  }
+}
+
 } // namespace torch::standalone


### PR DESCRIPTION
## Background

I am currently implementing shim versions of some of the aten operators that are used in Whisper model. And when I was implementing reshape() operator (used in scaled_dot_product_attention), I get an error on copying from a non-contigiuos tensor.

I have written a write-up for this error: [Problem with copy_ function of SlimTensor](https://docs.google.com/document/d/18Q9Su1aGuev51kZi4KN9Lc3j-k0WEbRa7zunRGPfjqQ/edit?usp=sharing)

## What is the PR about?

In this PR, I have fixed that issue.  The issue is:

SlimTensor has a member function `copy_` which eventually is designed to copy exactly that - a single, flat chunk of memory from a source (other) to a destination.
```
SlimTensor copy_(const SlimTensor& other) {
	storage_->clone(other.storage(), other.nbytes(), other.storage_offset());
	reutrn *this;
}
```
But this assumption is only true for **contiguous tensors**.

It does not work for **non-contiguous tensors**, like those created by `transpose()` and `permute()`, or some slicing operations. 

As we already know that a `non-contiguous tensor’s` elements are scattered throughout memory (like from a sequential perspective), and the tensor’s strides are tells us how to jump from one element to the next one. 

But the problem is memcpy inside the storage.h (that we use inside Storage::clone()) ignores strides entirely so it leads to incorrect data benign copied.


## Testing

I added two unit test for both contiguous tensor and non-contiguous tensor.


Note: I am still unsure if this solution is the most optimal one so I wanted to open up a new PR instead of adding it a part of reshape operator. 

```
(pytorch-3.12) [serhatgundem@devvm2480.eag0 /data/users/serhatgundem/pytorch_fork (fix_copying_noncontiguous_tensor_issue)]$ ./build/bin/test_aoti_standalone

[----------] 6 tests from SlimTensorInternalTest
[ RUN      ] SlimTensorInternalTest.SetSizesContiguous
[       OK ] SlimTensorInternalTest.SetSizesContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.SetSizesAndStridesNonContiguous
[       OK ] SlimTensorInternalTest.SetSizesAndStridesNonContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.EmptyTensorRestride
[       OK ] SlimTensorInternalTest.EmptyTensorRestride (0 ms)
[ RUN      ] SlimTensorInternalTest.CopyFromContiguous
[       OK ] SlimTensorInternalTest.CopyFromContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.CopyFromNonContiguous
[       OK ] SlimTensorInternalTest.CopyFromNonContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.CopyFromNonContiguousCuda
[       OK ] SlimTensorInternalTest.CopyFromNonContiguousCuda (5 ms)
[----------] 6 tests from SlimTensorInternalTest (5 ms total)

```

cc: @desertfire @angelayi @yushangdi
