### PR TITLE
Implement reshape

### DIFF
--- a/test/cpp/aoti_standalone/test_reshape.cpp
+++ b/test/cpp/aoti_standalone/test_reshape.cpp
@@ -1,0 +1,135 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <torch/csrc/inductor/aoti_standalone/cpu/reshape.h>
+#include <torch/csrc/inductor/aoti_standalone/factory.h>
+#include <torch/standalone/slim_tensor/slim_tensor.h>
+#include <torch/torch.h>
+
+using ::testing::ElementsAreArray;
+
+// Test Case 1: Reshape on a contiguous tensor that can be performed as a view.
+TEST(ReshapeTest, ReshapeAsView) {
+  // 1. Setup
+  at::Tensor at_tensor = at::arange(12, at::kFloat).reshape({3, 4});
+  torch::standalone::SlimTensor slim_tensor_self =
+      torch::standalone::create_tensor_from_blob(
+          at_tensor.data_ptr(),
+          c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
+          c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
+          at::kFloat);
+  ASSERT_TRUE(slim_tensor_self.is_contiguous());
+
+  // 2. Action
+  std::vector<int64_t> new_shape_vec = {2, 6};
+  AtenTensorHandle result_handle = nullptr;
+  AOTITorchError err = aoti_torch_cpu_reshape(
+      reinterpret_cast<AtenTensorHandle>(&slim_tensor_self),
+      new_shape_vec.data(),
+      new_shape_vec.size(),
+      &result_handle);
+  ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
+  torch::standalone::SlimTensor* slim_result =
+      reinterpret_cast<torch::standalone::SlimTensor*>(result_handle);
+
+  // For comparison, get the ground-truth result from ATen
+  at::Tensor at_result =
+      at::reshape(at_tensor, c10::IntArrayRef(new_shape_vec));
+
+  // 3. Verify
+  ASSERT_NE(slim_result, nullptr);
+  EXPECT_THAT(slim_result->sizes(), ElementsAreArray(at_result.sizes()));
+  EXPECT_THAT(slim_result->strides(), ElementsAreArray(at_result.strides()));
+  EXPECT_TRUE(slim_result->is_contiguous()); // Reshaping a contiguous tensor
+                                             // should remain contiguous
+
+  // CRITICAL: Verify it's a view by checking that the data pointer is unchanged
+  EXPECT_EQ(slim_result->data_ptr(), at_tensor.data_ptr());
+
+  delete slim_result;
+}
+
+// Test Case 2: Reshape on a non-contiguous tensor, which should trigger a copy.
+TEST(ReshapeTest, ReshapeWithCopy) {
+  // 1. Setup: Create a non-contiguous tensor by transposing it.
+  at::Tensor at_tensor_original = at::arange(12, at::kFloat).reshape({3, 4});
+  at::Tensor at_tensor_transposed = at::transpose(at_tensor_original, 0, 1);
+  ASSERT_FALSE(at_tensor_transposed.is_contiguous());
+
+  torch::standalone::SlimTensor slim_tensor_self =
+      torch::standalone::create_tensor_from_blob(
+          at_tensor_transposed.data_ptr(),
+          c10::IntArrayRef(
+              at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
+          c10::IntArrayRef(
+              at_tensor_transposed.strides().data(),
+              at_tensor_transposed.dim()),
+          at::kFloat);
+
+  // 2. Action: Reshape the non-contiguous tensor. This cannot be a view.
+  std::vector<int64_t> new_shape_vec = {2, 6};
+  AtenTensorHandle result_handle = nullptr;
+
+  AOTITorchError err = aoti_torch_cpu_reshape(
+      reinterpret_cast<AtenTensorHandle>(&slim_tensor_self),
+      new_shape_vec.data(),
+      new_shape_vec.size(),
+      &result_handle);
+
+  ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
+  torch::standalone::SlimTensor* slim_result =
+      reinterpret_cast<torch::standalone::SlimTensor*>(result_handle);
+
+  at::Tensor at_result =
+      at::reshape(at_tensor_transposed, c10::IntArrayRef(new_shape_vec));
+
+  // 3. Verify
+  ASSERT_NE(slim_result, nullptr);
+  EXPECT_THAT(slim_result->sizes(), ElementsAreArray(at_result.sizes()));
+  EXPECT_TRUE(slim_result->is_contiguous());
+
+  // CRITICAL: Verify a copy was made by checking that the data pointer is
+  // DIFFERENT
+  EXPECT_NE(slim_result->data_ptr(), at_tensor_original.data_ptr());
+
+  // Verify the data itself is correct by comparing to the ATen result
+  at::Tensor slim_result_aten_view = at::from_blob(
+      slim_result->data_ptr(),
+      slim_result->sizes(),
+      slim_result->strides(),
+      at::kFloat);
+  ASSERT_TRUE(at::equal(slim_result_aten_view, at_result));
+
+  delete slim_result;
+}
+
+// Test Case 3: Reshape with an inferred dimension (-1).
+TEST(ReshapeTest, ReshapeWithInferredDimension) {
+  // 1. Setup
+  at::Tensor at_tensor = at::arange(12, at::kFloat).reshape({3, 4});
+  torch::standalone::SlimTensor slim_tensor_self =
+      torch::standalone::create_tensor_from_blob(
+          at_tensor.data_ptr(),
+          c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
+          c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
+          at::kFloat);
+
+  // 2. Action: Propose a shape with -1
+  std::vector<int64_t> new_shape_vec = {2, -1, 3};
+  AtenTensorHandle result_handle = nullptr;
+  AOTITorchError err = aoti_torch_cpu_reshape(
+      reinterpret_cast<AtenTensorHandle>(&slim_tensor_self),
+      new_shape_vec.data(),
+      new_shape_vec.size(),
+      &result_handle);
+  ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
+  torch::standalone::SlimTensor* slim_result =
+      reinterpret_cast<torch::standalone::SlimTensor*>(result_handle);
+
+  // 3. Verify: The inferred shape should be {2, 2, 3}
+  EXPECT_THAT(slim_result->sizes(), ElementsAreArray({2, 2, 3}));
+  EXPECT_EQ(
+      slim_result->data_ptr(), at_tensor.data_ptr()); // Should still be a view
+
+  delete slim_result;
+}

--- a/test/cpp/aoti_standalone/test_reshape.cpp
+++ b/test/cpp/aoti_standalone/test_reshape.cpp
@@ -14,12 +14,11 @@ using torch::standalone::SlimTensor;
 TEST(ReshapeTest, ReshapeAsView) {
   // 1. Setup
   at::Tensor at_tensor = at::arange(12, at::kFloat).reshape({3, 4});
-  SlimTensor slim_tensor_self =
-      torch::standalone::create_tensor_from_blob(
-          at_tensor.data_ptr(),
-          c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
-          c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
-          at::kFloat);
+  SlimTensor slim_tensor_self = torch::standalone::create_tensor_from_blob(
+      at_tensor.data_ptr(),
+      c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
+      c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
+      at::kFloat);
   ASSERT_TRUE(slim_tensor_self.is_contiguous());
 
   // 2. Action
@@ -31,8 +30,7 @@ TEST(ReshapeTest, ReshapeAsView) {
       new_shape_vec.size(),
       &result_handle);
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  SlimTensor* slim_result =
-      reinterpret_cast<SlimTensor*>(result_handle);
+  SlimTensor* slim_result = reinterpret_cast<SlimTensor*>(result_handle);
 
   // For comparison, get the ground-truth result from ATen
   at::Tensor at_result =
@@ -58,15 +56,13 @@ TEST(ReshapeTest, ReshapeWithCopy) {
   at::Tensor at_tensor_transposed = at::transpose(at_tensor_original, 0, 1);
   ASSERT_FALSE(at_tensor_transposed.is_contiguous());
 
-  SlimTensor slim_tensor_self =
-      torch::standalone::create_tensor_from_blob(
-          at_tensor_transposed.data_ptr(),
-          c10::IntArrayRef(
-              at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
-          c10::IntArrayRef(
-              at_tensor_transposed.strides().data(),
-              at_tensor_transposed.dim()),
-          at::kFloat);
+  SlimTensor slim_tensor_self = torch::standalone::create_tensor_from_blob(
+      at_tensor_transposed.data_ptr(),
+      c10::IntArrayRef(
+          at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
+      c10::IntArrayRef(
+          at_tensor_transposed.strides().data(), at_tensor_transposed.dim()),
+      at::kFloat);
 
   // 2. Action: Reshape the non-contiguous tensor. This cannot be a view.
   std::vector<int64_t> new_shape_vec = {2, 6};
@@ -79,8 +75,7 @@ TEST(ReshapeTest, ReshapeWithCopy) {
       &result_handle);
 
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  SlimTensor* slim_result =
-      reinterpret_cast<SlimTensor*>(result_handle);
+  SlimTensor* slim_result = reinterpret_cast<SlimTensor*>(result_handle);
 
   at::Tensor at_result =
       at::reshape(at_tensor_transposed, c10::IntArrayRef(new_shape_vec));
@@ -109,12 +104,11 @@ TEST(ReshapeTest, ReshapeWithCopy) {
 TEST(ReshapeTest, ReshapeWithInferredDimension) {
   // 1. Setup
   at::Tensor at_tensor = at::arange(12, at::kFloat).reshape({3, 4});
-  SlimTensor slim_tensor_self =
-      torch::standalone::create_tensor_from_blob(
-          at_tensor.data_ptr(),
-          c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
-          c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
-          at::kFloat);
+  SlimTensor slim_tensor_self = torch::standalone::create_tensor_from_blob(
+      at_tensor.data_ptr(),
+      c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
+      c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
+      at::kFloat);
 
   // 2. Action: Propose a shape with -1
   std::vector<int64_t> new_shape_vec = {2, -1, 3};
@@ -125,8 +119,7 @@ TEST(ReshapeTest, ReshapeWithInferredDimension) {
       new_shape_vec.size(),
       &result_handle);
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  SlimTensor* slim_result =
-      reinterpret_cast<SlimTensor*>(result_handle);
+  SlimTensor* slim_result = reinterpret_cast<SlimTensor*>(result_handle);
 
   // 3. Verify: The inferred shape should be {2, 2, 3}
   EXPECT_THAT(slim_result->sizes(), ElementsAreArray({2, 2, 3}));
@@ -144,13 +137,12 @@ TEST(ReshapeTest, ReshapeAsViewCUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(cuda_device);
 
   at::Tensor at_tensor = at::arange(12, options).reshape({3, 4});
-  SlimTensor slim_tensor_self =
-      torch::standalone::create_tensor_from_blob(
-          at_tensor.data_ptr(),
-          c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
-          c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
-          at::kFloat,
-          cuda_device);
+  SlimTensor slim_tensor_self = torch::standalone::create_tensor_from_blob(
+      at_tensor.data_ptr(),
+      c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
+      c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
+      at::kFloat,
+      cuda_device);
 
   std::vector<int64_t> new_shape_vec = {2, 6};
   AtenTensorHandle result_handle = nullptr;
@@ -161,8 +153,7 @@ TEST(ReshapeTest, ReshapeAsViewCUDA) {
       &result_handle);
 
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  SlimTensor* slim_result =
-      reinterpret_cast<SlimTensor*>(result_handle);
+  SlimTensor* slim_result = reinterpret_cast<SlimTensor*>(result_handle);
 
   ASSERT_NE(slim_result, nullptr);
   EXPECT_TRUE(slim_result->device().is_cuda());
@@ -180,16 +171,14 @@ TEST(ReshapeTest, ReshapeWithCopyCUDA) {
   at::Tensor at_tensor_original = at::arange(12, options).reshape({3, 4});
   at::Tensor at_tensor_transposed = at::transpose(at_tensor_original, 0, 1);
 
-  SlimTensor slim_tensor_self =
-      torch::standalone::create_tensor_from_blob(
-          at_tensor_transposed.data_ptr(),
-          c10::IntArrayRef(
-              at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
-          c10::IntArrayRef(
-              at_tensor_transposed.strides().data(),
-              at_tensor_transposed.dim()),
-          at::kFloat,
-          cuda_device);
+  SlimTensor slim_tensor_self = torch::standalone::create_tensor_from_blob(
+      at_tensor_transposed.data_ptr(),
+      c10::IntArrayRef(
+          at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
+      c10::IntArrayRef(
+          at_tensor_transposed.strides().data(), at_tensor_transposed.dim()),
+      at::kFloat,
+      cuda_device);
 
   std::vector<int64_t> new_shape_vec = {2, 6};
   AtenTensorHandle result_handle = nullptr;
@@ -199,8 +188,7 @@ TEST(ReshapeTest, ReshapeWithCopyCUDA) {
       new_shape_vec.size(),
       &result_handle);
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  SlimTensor* slim_result =
-      reinterpret_cast<SlimTensor*>(result_handle);
+  SlimTensor* slim_result = reinterpret_cast<SlimTensor*>(result_handle);
 
   ASSERT_NE(slim_result, nullptr);
   EXPECT_TRUE(slim_result->device().is_cuda());
@@ -231,16 +219,14 @@ TEST(ReshapeTest, ReshapeWithCopyCUDAInt64) {
   at::Tensor at_tensor_original = at::arange(12, options).reshape({3, 4});
   at::Tensor at_tensor_transposed = at::transpose(at_tensor_original, 0, 1);
 
-  SlimTensor slim_tensor_self =
-      torch::standalone::create_tensor_from_blob(
-          at_tensor_transposed.data_ptr(),
-          c10::IntArrayRef(
-              at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
-          c10::IntArrayRef(
-              at_tensor_transposed.strides().data(),
-              at_tensor_transposed.dim()),
-          at::kLong,
-          cuda_device);
+  SlimTensor slim_tensor_self = torch::standalone::create_tensor_from_blob(
+      at_tensor_transposed.data_ptr(),
+      c10::IntArrayRef(
+          at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
+      c10::IntArrayRef(
+          at_tensor_transposed.strides().data(), at_tensor_transposed.dim()),
+      at::kLong,
+      cuda_device);
 
   std::vector<int64_t> new_shape_vec = {2, 6};
   AtenTensorHandle result_handle = nullptr;
@@ -250,8 +236,7 @@ TEST(ReshapeTest, ReshapeWithCopyCUDAInt64) {
       new_shape_vec.size(),
       &result_handle);
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  SlimTensor* slim_result =
-      reinterpret_cast<SlimTensor*>(result_handle);
+  SlimTensor* slim_result = reinterpret_cast<SlimTensor*>(result_handle);
 
   ASSERT_NE(slim_result, nullptr);
   EXPECT_TRUE(slim_result->device().is_cuda());

--- a/test/cpp/aoti_standalone/test_reshape.cpp
+++ b/test/cpp/aoti_standalone/test_reshape.cpp
@@ -1,18 +1,20 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <torch/csrc/inductor/aoti_standalone/cpu/reshape.h>
-#include <torch/csrc/inductor/aoti_standalone/factory.h>
-#include <torch/standalone/slim_tensor/slim_tensor.h>
 #include <torch/torch.h>
 
+#include <torch/csrc/inductor/aoti_standalone/cpu/reshape.h>
+#include <torch/csrc/inductor/aoti_standalone/cuda/reshape.h>
+#include <torch/csrc/inductor/aoti_standalone/factory.h>
+#include <torch/standalone/slim_tensor/slim_tensor.h>
+
 using ::testing::ElementsAreArray;
+using torch::standalone::SlimTensor;
 
 // Test Case 1: Reshape on a contiguous tensor that can be performed as a view.
 TEST(ReshapeTest, ReshapeAsView) {
   // 1. Setup
   at::Tensor at_tensor = at::arange(12, at::kFloat).reshape({3, 4});
-  torch::standalone::SlimTensor slim_tensor_self =
+  SlimTensor slim_tensor_self =
       torch::standalone::create_tensor_from_blob(
           at_tensor.data_ptr(),
           c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
@@ -29,8 +31,8 @@ TEST(ReshapeTest, ReshapeAsView) {
       new_shape_vec.size(),
       &result_handle);
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  torch::standalone::SlimTensor* slim_result =
-      reinterpret_cast<torch::standalone::SlimTensor*>(result_handle);
+  SlimTensor* slim_result =
+      reinterpret_cast<SlimTensor*>(result_handle);
 
   // For comparison, get the ground-truth result from ATen
   at::Tensor at_result =
@@ -56,7 +58,7 @@ TEST(ReshapeTest, ReshapeWithCopy) {
   at::Tensor at_tensor_transposed = at::transpose(at_tensor_original, 0, 1);
   ASSERT_FALSE(at_tensor_transposed.is_contiguous());
 
-  torch::standalone::SlimTensor slim_tensor_self =
+  SlimTensor slim_tensor_self =
       torch::standalone::create_tensor_from_blob(
           at_tensor_transposed.data_ptr(),
           c10::IntArrayRef(
@@ -77,8 +79,8 @@ TEST(ReshapeTest, ReshapeWithCopy) {
       &result_handle);
 
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  torch::standalone::SlimTensor* slim_result =
-      reinterpret_cast<torch::standalone::SlimTensor*>(result_handle);
+  SlimTensor* slim_result =
+      reinterpret_cast<SlimTensor*>(result_handle);
 
   at::Tensor at_result =
       at::reshape(at_tensor_transposed, c10::IntArrayRef(new_shape_vec));
@@ -107,7 +109,7 @@ TEST(ReshapeTest, ReshapeWithCopy) {
 TEST(ReshapeTest, ReshapeWithInferredDimension) {
   // 1. Setup
   at::Tensor at_tensor = at::arange(12, at::kFloat).reshape({3, 4});
-  torch::standalone::SlimTensor slim_tensor_self =
+  SlimTensor slim_tensor_self =
       torch::standalone::create_tensor_from_blob(
           at_tensor.data_ptr(),
           c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
@@ -123,8 +125,8 @@ TEST(ReshapeTest, ReshapeWithInferredDimension) {
       new_shape_vec.size(),
       &result_handle);
   ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
-  torch::standalone::SlimTensor* slim_result =
-      reinterpret_cast<torch::standalone::SlimTensor*>(result_handle);
+  SlimTensor* slim_result =
+      reinterpret_cast<SlimTensor*>(result_handle);
 
   // 3. Verify: The inferred shape should be {2, 2, 3}
   EXPECT_THAT(slim_result->sizes(), ElementsAreArray({2, 2, 3}));
@@ -133,3 +135,141 @@ TEST(ReshapeTest, ReshapeWithInferredDimension) {
 
   delete slim_result;
 }
+
+#if defined(USE_CUDA)
+TEST(ReshapeTest, ReshapeAsViewCUDA) {
+  if (!torch::cuda::is_available())
+    GTEST_SKIP() << "CUDA not available";
+  at::Device cuda_device(at::kCUDA);
+  auto options = at::TensorOptions().dtype(at::kFloat).device(cuda_device);
+
+  at::Tensor at_tensor = at::arange(12, options).reshape({3, 4});
+  SlimTensor slim_tensor_self =
+      torch::standalone::create_tensor_from_blob(
+          at_tensor.data_ptr(),
+          c10::IntArrayRef(at_tensor.sizes().data(), at_tensor.dim()),
+          c10::IntArrayRef(at_tensor.strides().data(), at_tensor.dim()),
+          at::kFloat,
+          cuda_device);
+
+  std::vector<int64_t> new_shape_vec = {2, 6};
+  AtenTensorHandle result_handle = nullptr;
+  AOTITorchError err = aoti_torch_cuda_reshape(
+      reinterpret_cast<AtenTensorHandle>(&slim_tensor_self),
+      new_shape_vec.data(),
+      new_shape_vec.size(),
+      &result_handle);
+
+  ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
+  SlimTensor* slim_result =
+      reinterpret_cast<SlimTensor*>(result_handle);
+
+  ASSERT_NE(slim_result, nullptr);
+  EXPECT_TRUE(slim_result->device().is_cuda());
+  EXPECT_EQ(slim_result->data_ptr(), at_tensor.data_ptr());
+
+  delete slim_result;
+}
+
+TEST(ReshapeTest, ReshapeWithCopyCUDA) {
+  if (!torch::cuda::is_available())
+    GTEST_SKIP() << "CUDA not available";
+  at::Device cuda_device(at::kCUDA);
+  auto options = at::TensorOptions().dtype(at::kFloat).device(cuda_device);
+
+  at::Tensor at_tensor_original = at::arange(12, options).reshape({3, 4});
+  at::Tensor at_tensor_transposed = at::transpose(at_tensor_original, 0, 1);
+
+  SlimTensor slim_tensor_self =
+      torch::standalone::create_tensor_from_blob(
+          at_tensor_transposed.data_ptr(),
+          c10::IntArrayRef(
+              at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
+          c10::IntArrayRef(
+              at_tensor_transposed.strides().data(),
+              at_tensor_transposed.dim()),
+          at::kFloat,
+          cuda_device);
+
+  std::vector<int64_t> new_shape_vec = {2, 6};
+  AtenTensorHandle result_handle = nullptr;
+  AOTITorchError err = aoti_torch_cuda_reshape(
+      reinterpret_cast<AtenTensorHandle>(&slim_tensor_self),
+      new_shape_vec.data(),
+      new_shape_vec.size(),
+      &result_handle);
+  ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
+  SlimTensor* slim_result =
+      reinterpret_cast<SlimTensor*>(result_handle);
+
+  ASSERT_NE(slim_result, nullptr);
+  EXPECT_TRUE(slim_result->device().is_cuda());
+  EXPECT_NE(slim_result->data_ptr(), at_tensor_original.data_ptr());
+
+  // Verify data content by copying back to CPU
+  at::Tensor at_result =
+      at::reshape(at_tensor_transposed, c10::IntArrayRef(new_shape_vec));
+  SlimTensor slim_result_cpu =
+      slim_result->to(c10::Device(c10::DeviceType::CPU));
+  at::Tensor at_result_cpu = at_result.to(at::kCPU);
+
+  float* slim_data_cpu = static_cast<float*>(slim_result_cpu.data_ptr());
+  float* at_data_cpu = static_cast<float*>(at_result_cpu.data_ptr());
+  for (int64_t i = 0; i < at_result_cpu.numel(); ++i) {
+    EXPECT_FLOAT_EQ(slim_data_cpu[i], at_data_cpu[i]);
+  }
+
+  delete slim_result;
+}
+
+TEST(ReshapeTest, ReshapeWithCopyCUDAInt64) {
+  if (!torch::cuda::is_available())
+    GTEST_SKIP() << "CUDA not available";
+  at::Device cuda_device(at::kCUDA);
+  auto options = at::TensorOptions().dtype(at::kLong).device(cuda_device);
+
+  at::Tensor at_tensor_original = at::arange(12, options).reshape({3, 4});
+  at::Tensor at_tensor_transposed = at::transpose(at_tensor_original, 0, 1);
+
+  SlimTensor slim_tensor_self =
+      torch::standalone::create_tensor_from_blob(
+          at_tensor_transposed.data_ptr(),
+          c10::IntArrayRef(
+              at_tensor_transposed.sizes().data(), at_tensor_transposed.dim()),
+          c10::IntArrayRef(
+              at_tensor_transposed.strides().data(),
+              at_tensor_transposed.dim()),
+          at::kLong,
+          cuda_device);
+
+  std::vector<int64_t> new_shape_vec = {2, 6};
+  AtenTensorHandle result_handle = nullptr;
+  AOTITorchError err = aoti_torch_cuda_reshape(
+      reinterpret_cast<AtenTensorHandle>(&slim_tensor_self),
+      new_shape_vec.data(),
+      new_shape_vec.size(),
+      &result_handle);
+  ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
+  SlimTensor* slim_result =
+      reinterpret_cast<SlimTensor*>(result_handle);
+
+  ASSERT_NE(slim_result, nullptr);
+  EXPECT_TRUE(slim_result->device().is_cuda());
+  EXPECT_NE(slim_result->data_ptr(), at_tensor_original.data_ptr());
+
+  // Verify data content by copying back to CPU
+  at::Tensor at_result =
+      at::reshape(at_tensor_transposed, c10::IntArrayRef(new_shape_vec));
+  SlimTensor slim_result_cpu =
+      slim_result->to(c10::Device(c10::DeviceType::CPU));
+  at::Tensor at_result_cpu = at_result.to(at::kCPU);
+
+  int64_t* slim_data_cpu = static_cast<int64_t*>(slim_result_cpu.data_ptr());
+  int64_t* at_data_cpu = static_cast<int64_t*>(at_result_cpu.data_ptr());
+  for (int64_t i = 0; i < at_result_cpu.numel(); ++i) {
+    EXPECT_EQ(slim_data_cpu[i], at_data_cpu[i]);
+  }
+
+  delete slim_result;
+}
+#endif

--- a/torch/csrc/inductor/aoti_standalone/cpu/reshape.h
+++ b/torch/csrc/inductor/aoti_standalone/cpu/reshape.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <torch/csrc/inductor/aoti_standalone/c/shim.h>
+#include <torch/standalone/reshape_template.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+AOTITorchError aoti_torch_cpu_reshape(
+    AtenTensorHandle self,
+    const int64_t* shape,
+    int64_t shape_len_,
+    AtenTensorHandle* ret0) {
+  const torch::standalone::SlimTensor* self_tensor =
+      reinterpret_cast<const torch::standalone::SlimTensor*>(self);
+
+  c10::IntArrayRef shape_ref(shape, shape_len_);
+
+  torch::standalone::SlimTensor result_tensor =
+      torch::standalone::_reshape<torch::standalone::SlimTensor>(
+          *self_tensor, shape_ref);
+
+  *ret0 = reinterpret_cast<AtenTensorHandle>(
+      new torch::standalone::SlimTensor(std::move(result_tensor)));
+  return AOTI_TORCH_SUCCESS;
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/torch/csrc/inductor/aoti_standalone/cuda/reshape.h
+++ b/torch/csrc/inductor/aoti_standalone/cuda/reshape.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <torch/csrc/inductor/aoti_standalone/c/shim.h>
+#include <torch/standalone/reshape_template.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+AOTITorchError aoti_torch_cuda_reshape(
+    AtenTensorHandle self,
+    const int64_t* shape,
+    int64_t shape_len_,
+    AtenTensorHandle* ret0) {
+  const torch::standalone::SlimTensor* self_tensor =
+      reinterpret_cast<const torch::standalone::SlimTensor*>(self);
+
+  c10::IntArrayRef shape_ref(shape, shape_len_);
+
+  torch::standalone::SlimTensor result_tensor =
+      torch::standalone::_reshape<torch::standalone::SlimTensor>(
+          *self_tensor, shape_ref);
+
+  *ret0 = reinterpret_cast<AtenTensorHandle>(
+      new torch::standalone::SlimTensor(std::move(result_tensor)));
+  return AOTI_TORCH_SUCCESS;
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/torch/standalone/reshape_template.h
+++ b/torch/standalone/reshape_template.h
@@ -1,29 +1,11 @@
 #pragma once
 
-#include <torch/csrc/inductor/aoti_standalone/factory.h>
-#include <torch/standalone/slim_tensor/utils.h>
 #include <torch/standalone/util/ReshapeUtils.h>
 
 #include <c10/util/Optional.h>
 #include <optional>
 #include <vector>
 namespace torch::standalone {
-
-template <typename T>
-inline T clone_contiguous(const T& self) {
-  std::vector<int64_t> contig_strides =
-      compute_contiguous_strides(self.sizes());
-
-  T result = empty_tensor<T>(
-      self.sizes(),
-      c10::IntArrayRef(contig_strides),
-      self.dtype(),
-      self.device(),
-      0);
-  // copy the data from (potentially non-contiguous) the self tensor
-  result.copy_(self);
-  return result;
-}
 
 template <typename T>
 inline T _reshape(const T& self, c10::IntArrayRef proposed_shape) {
@@ -45,7 +27,7 @@ inline T _reshape(const T& self, c10::IntArrayRef proposed_shape) {
   }
 
   // if a view is not possible, create a contiguous clone and reshape that
-  T contiguous_clone = clone_contiguous(self);
+  T contiguous_clone = self.clone_contiguous();
 
   // after cloning, the tensor is already contiguous. We just need to update
   // its metadata to reflect the new shape. This is effectively a view of

--- a/torch/standalone/reshape_template.h
+++ b/torch/standalone/reshape_template.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <torch/csrc/inductor/aoti_standalone/factory.h>
+#include <torch/standalone/slim_tensor/utils.h>
+#include <torch/standalone/util/ReshapeUtils.h>
+
+#include <c10/util/Optional.h>
+#include <optional>
+#include <vector>
+namespace torch::standalone {
+
+template <typename T>
+inline T clone_contiguous(const T& self) {
+  std::vector<int64_t> contig_strides =
+      compute_contiguous_strides(self.sizes());
+
+  T result = empty_tensor<T>(
+      self.sizes(),
+      c10::IntArrayRef(contig_strides),
+      self.dtype(),
+      self.device(),
+      0);
+  // copy the data from (potentially non-contiguous) the self tensor
+  result.copy_(self);
+  return result;
+}
+
+template <typename T>
+inline T _reshape(const T& self, c10::IntArrayRef proposed_shape) {
+  // TODO: implement infer_size
+  std::vector<int64_t> final_shape_vec =
+      infer_size(proposed_shape, self.numel());
+  c10::IntArrayRef final_shape(final_shape_vec);
+
+  // `compute_stride` return the proper strides to use if this
+  // `reshape` can be just a view.
+  std::optional<std::vector<int64_t>> new_strides_opt =
+      compute_stride(self.sizes(), self.strides(), final_shape);
+
+  // create a view if possible
+  if (new_strides_opt.has_value()) {
+    T result = self; // creates a copy that shares the Storage
+    result.as_strided_(
+        final_shape,
+        c10::IntArrayRef(new_strides_opt.value()),
+        self.storage_offset());
+    return result;
+  }
+
+  // if a view is not possible, create a contiguous clone and reshape that
+  T contiguous_clone = clone_contiguous(self);
+
+  // after cloning, the tensor is already contiguous. We just need to update
+  // its metadata to reflect the new shape. This is effectively a view of
+  // the new contiguous clone
+  return contiguous_clone.reshape_as_view(final_shape);
+}
+
+} // namespace torch::standalone

--- a/torch/standalone/reshape_template.h
+++ b/torch/standalone/reshape_template.h
@@ -27,7 +27,6 @@ inline T clone_contiguous(const T& self) {
 
 template <typename T>
 inline T _reshape(const T& self, c10::IntArrayRef proposed_shape) {
-  // TODO: implement infer_size
   std::vector<int64_t> final_shape_vec =
       infer_size(proposed_shape, self.numel());
   c10::IntArrayRef final_shape(final_shape_vec);
@@ -41,9 +40,7 @@ inline T _reshape(const T& self, c10::IntArrayRef proposed_shape) {
   if (new_strides_opt.has_value()) {
     T result = self; // creates a copy that shares the Storage
     result.as_strided_(
-        final_shape,
-        c10::IntArrayRef(new_strides_opt.value()),
-        self.storage_offset());
+        final_shape, new_strides_opt.value(), self.storage_offset());
     return result;
   }
 

--- a/torch/standalone/slim_tensor/slim_tensor.h
+++ b/torch/standalone/slim_tensor/slim_tensor.h
@@ -211,29 +211,26 @@ class SlimTensor {
   SlimTensor copy_(const SlimTensor& other) {
     TORCH_CHECK(
         this->numel() == other.numel(), "copy_: numel of tensors must match");
-    TORCH_CHECK(
-        this->is_contiguous(), "copy_: destination tensor must be contiguous");
-
-    // Case 1: The source tensor is also contiguous. We can do a fast bulk copy.
-    // This works for both CPU and CUDA because storage_->clone() is
-    // device-aware.
-    if (other.is_contiguous()) {
-      storage_->clone(other.storage(), other.nbytes(), other.storage_offset());
-      return *this;
-    }
-
-    // Case 2: source is not contiguous we must perform a element-wise copy
-    // that respects source's (other) strides.
-    const size_t elem_size = c10::elementSize(dtype_);
-    char* dst_data = static_cast<char*>(this->data_ptr());
-    const char* src_data = static_cast<const char*>(other.data_ptr()) +
-        other.storage_offset() * elem_size;
 
     if (this->numel() == 0) {
       return *this;
     }
 
-    std::vector<int64_t> counter(other.dim(), 0);
+    // Case 1: Both tensors are contiguous. We can do a fast bulk copy.
+    if (this->is_contiguous() && other.is_contiguous()) {
+      storage_->clone(other.storage(), other.nbytes(), other.storage_offset());
+      return *this;
+    }
+
+    // Case 2: At least one tensor is non-contiguous, perform element-wise copy
+    // that respects both source and destination strides.
+    const size_t elem_size = c10::elementSize(dtype_);
+    char* dst_data = static_cast<char*>(this->data_ptr()) +
+        this->storage_offset() * elem_size;
+    const char* src_data = static_cast<const char*>(other.data_ptr()) +
+        other.storage_offset() * elem_size;
+
+    std::vector<int64_t> counter(this->dim(), 0);
     for (size_t i = 0; i < this->numel(); i++) {
       // Compute src offset in elements
       int64_t src_offset = 0;
@@ -241,16 +238,22 @@ class SlimTensor {
         src_offset += counter[d] * other.stride(d);
       }
 
+      // Compute dst offset in elements
+      int64_t dst_offset = 0;
+      for (size_t d = 0; d < this->dim(); d++) {
+        dst_offset += counter[d] * this->stride(d);
+      }
+
       // Copy elem_size bytes from src to dst
       if (this->device().is_cpu() && other.device().is_cpu()) {
         std::memcpy(
-            dst_data + i * elem_size,
+            dst_data + dst_offset * elem_size,
             src_data + src_offset * elem_size,
             elem_size);
       } else if (this->device().is_cuda() || other.device().is_cuda()) {
 #if defined(USE_CUDA)
         DeviceTraits<c10::DeviceType::CUDA>::memcpy(
-            dst_data + i * elem_size,
+            dst_data + dst_offset * elem_size,
             src_data + src_offset * elem_size,
             elem_size,
             device(), // dst device
@@ -261,9 +264,9 @@ class SlimTensor {
 #endif
       }
       // Increment the multi-dimensional counter
-      for (int64_t d = static_cast<int64_t>(other.dim()) - 1; d >= 0; --d) {
+      for (int64_t d = static_cast<int64_t>(this->dim()) - 1; d >= 0; --d) {
         counter[d]++;
-        if (counter[d] < other.size(d)) {
+        if (counter[d] < this->size(d)) {
           break;
         }
         counter[d] = 0;

--- a/torch/standalone/slim_tensor/slim_tensor.h
+++ b/torch/standalone/slim_tensor/slim_tensor.h
@@ -377,6 +377,13 @@ class SlimTensor {
     return _transpose(*this, dim0, dim1);
   }
 
+  SlimTensor& reshape_as_view(c10::IntArrayRef new_shape) {
+    this->set_sizes_contiguous(new_shape);
+    // after a clone, the new view is relative to the start of the storage.
+    this->storage_offset_ = 0;
+    return *this;
+  }
+
  private:
   void refresh_numel() {
     numel_ =

--- a/torch/standalone/slim_tensor/utils.h
+++ b/torch/standalone/slim_tensor/utils.h
@@ -195,40 +195,4 @@ inline std::vector<int64_t> compute_contiguous_strides(c10::IntArrayRef sizes) {
 #endif
 }
 
-template <typename scalar_t>
-void elementwise_copy(
-    scalar_t* dst_data,
-    const scalar_t* src_data,
-    size_t numel,
-    size_t ndim,
-    c10::IntArrayRef sizes,
-    c10::IntArrayRef src_strides) {
-  if (numel == 0) {
-    return;
-  }
-
-  std::vector<int64_t> counter(ndim, 0);
-  for (size_t i = 0; i < numel; i++) {
-    int64_t src_offset = 0;
-    for (size_t d = 0; d < ndim; d++) {
-      src_offset += counter[d] * src_strides[d];
-    }
-
-    // the destination is contiguous so its offset is simply the element index
-    // 'i'.
-    dst_data[i] = src_data[src_offset];
-
-    // increment the multi-dimensional counter to find the next logical element
-    int64_t current_dim = static_cast<int64_t>(ndim) - 1;
-    while (current_dim >= 0) {
-      counter[current_dim]++;
-      if (counter[current_dim] < sizes[current_dim]) {
-        break;
-      }
-      counter[current_dim] = 0;
-      current_dim--;
-    }
-  }
-}
-
 } // namespace torch::standalone

--- a/torch/standalone/slim_tensor/utils.h
+++ b/torch/standalone/slim_tensor/utils.h
@@ -195,4 +195,40 @@ inline std::vector<int64_t> compute_contiguous_strides(c10::IntArrayRef sizes) {
 #endif
 }
 
+template <typename scalar_t>
+void elementwise_copy(
+    scalar_t* dst_data,
+    const scalar_t* src_data,
+    size_t numel,
+    size_t ndim,
+    c10::IntArrayRef sizes,
+    c10::IntArrayRef src_strides) {
+  if (numel == 0) {
+    return;
+  }
+
+  std::vector<int64_t> counter(ndim, 0);
+  for (size_t i = 0; i < numel; i++) {
+    int64_t src_offset = 0;
+    for (size_t d = 0; d < ndim; d++) {
+      src_offset += counter[d] * src_strides[d];
+    }
+
+    // the destination is contiguous so its offset is simply the element index
+    // 'i'.
+    dst_data[i] = src_data[src_offset];
+
+    // increment the multi-dimensional counter to find the next logical element
+    int64_t current_dim = static_cast<int64_t>(ndim) - 1;
+    while (current_dim >= 0) {
+      counter[current_dim]++;
+      if (counter[current_dim] < sizes[current_dim]) {
+        break;
+      }
+      counter[current_dim] = 0;
+      current_dim--;
+    }
+  }
+}
+
 } // namespace torch::standalone

--- a/torch/standalone/util/ReshapeUtils.h
+++ b/torch/standalone/util/ReshapeUtils.h
@@ -1,0 +1,118 @@
+#pragma once
+#include <numeric>
+#include <optional>
+#include <vector>
+
+#include <c10/util/ArrayRef.h>
+
+#include <torch/standalone/slim_tensor/utils.h>
+
+// calculates the final concrete shape by also filling in at most one '-1'
+// dimension.
+inline std::vector<int64_t> infer_size(c10::IntArrayRef shape, int64_t numel) {
+  int64_t new_size = 1;
+  std::optional<int64_t> infer_dim;
+  std::vector<int64_t> result_shape;
+  result_shape.reserve(shape.size());
+
+  int64_t ndim = static_cast<int64_t>(shape.size());
+
+  for (int64_t dim = 0; dim < ndim; dim++) {
+    if (shape[dim] == -1) {
+      TORCH_CHECK(!infer_dim.has_value(), "only one dimension can be inferred");
+      infer_dim = dim;
+      result_shape.push_back(-1); // placeholder
+    } else {
+      TORCH_CHECK(shape[dim] >= 0, "invalid shape dimension ", shape[dim]);
+      new_size *= shape[dim];
+      result_shape.push_back(shape[dim]);
+    }
+  }
+
+  if (infer_dim.has_value()) {
+    TORCH_CHECK(
+        new_size != 0,
+        "cannot reshape tensor of 0 elements into shape with -1");
+    TORCH_CHECK(
+        numel % new_size == 0, "shape is invalid for input size ", numel);
+    result_shape[*infer_dim] = numel / new_size;
+  } else {
+    TORCH_CHECK(
+        numel == new_size, "shape is invalid for input of size ", numel);
+  }
+  return result_shape;
+}
+
+// it determines if a reshape is possible as a view.
+// If so, it returns the new strides
+// If not, it returns an empty optional
+inline std::optional<std::vector<int64_t>> compute_stride(
+    c10::IntArrayRef old_sizes,
+    c10::IntArrayRef old_strides,
+    c10::IntArrayRef new_sizes) {
+  if (old_sizes.empty()) {
+    return std::vector<int64_t>(new_sizes.size(), -1);
+  }
+
+  // NOTE: stride is arbitrary in the numel() == 0 case;
+  // to match NumPy behavior we copy the strides if the size matches, otherwise
+  // we use the stride as if it were computed via resize.
+  // This could perhaps be combined with the below code, but the complexity
+  // didn't seem worth it.
+  size_t numel = torch::standalone::compute_numel(old_sizes);
+
+  if (numel == 0 && old_sizes == new_sizes) {
+    return old_strides.vec();
+  }
+
+  if (numel == 0) {
+    int64_t new_sizes_len = static_cast<int64_t>(new_sizes.size());
+    std::vector<int64_t> new_strides(new_sizes_len);
+    for (int64_t i = new_sizes_len - 1; i >= 0; i--) {
+      if (i == new_sizes_len - 1) {
+        new_strides[i] = 1;
+      } else {
+        new_strides[i] =
+            std::max<int64_t>(new_sizes[i + 1], 1) * new_strides[i + 1];
+      }
+    }
+    return new_strides;
+  }
+
+  std::vector<int64_t> new_strides(new_sizes.size());
+  int64_t view_d = static_cast<int64_t>(new_sizes.size()) - 1;
+  int64_t chunk_base_stride = old_strides.back();
+  int64_t tensor_numel = 1;
+  int64_t view_numel = 1;
+
+  for (int64_t tensor_d = static_cast<int64_t>(old_sizes.size()) - 1;
+       tensor_d >= 0;
+       tensor_d--) {
+    tensor_numel *= old_sizes[tensor_d];
+
+    bool is_chunk_end = (tensor_d == 0) ||
+        (old_sizes[tensor_d - 1] != 1 &&
+         old_strides[tensor_d - 1] != tensor_numel * chunk_base_stride);
+
+    if (is_chunk_end) {
+      while (view_d >= 0 &&
+             (view_numel < tensor_numel || new_sizes[view_d] == 1)) {
+        new_strides[view_d] = view_numel * chunk_base_stride;
+        view_numel *= new_sizes[view_d];
+        view_d--;
+      }
+      if (view_numel != tensor_numel) {
+        return std::nullopt; // Not viewable
+      }
+      if (tensor_d > 0) {
+        chunk_base_stride = old_strides[tensor_d - 1];
+        tensor_numel = 1;
+        view_numel = 1;
+      }
+    }
+  }
+  if (view_d != -1) {
+    return std::nullopt; // not viewable
+  }
+  return new_strides;
+}


### PR DESCRIPTION
## Context
I am implementing standalone shim versions of all the necessary operators for running the Whisper Model libtorch-free, thereby eliminating the dependency on ATen. This PR is related with `reshape_` operator.

This PR is built on top of [PR#9](https://github.com/desertfire/pytorch/pull/9). So we can ignore `copy_` function in `slim_tensor.h` and `test_slim_tensor.cpp`.

## Summary
- reshape():
    - reshape first tries to be a view. It checks if the underlying data can be re-interpreted into the new shape without a data copy. This is possible if the original tensor is contiguous.
    - If it can return a view, it does. And it shares data with the original.
    - If it cannot return a view (because the original tensor is not contiguous), reshape will not fail. Instead,
    - It will first create a contiguous copy of the data
    - And then perform reshape on that new, contiguous copy.

## What does this PR do?

In this PR, [reshape](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/TensorShape.cpp#L2068) operator is implemented.

`reshape` is used both in cuda and cpu so I had to implement:

- `aoti_standalone_cpu_transpose_int()`
- `aoti_standalone_cuda_transpose_int()`

And it is also used as a member function of SlimTensor. So I also added it as a member function.

`reshape` uses some other helper functions, so I will link those functions with the aten implementations below:

- `compute_stride()` inside torch/standalone/util/ReshapeUtils.h
    -  it corresponds to this aten implementation: [computeStride()](https://www.internalfb.com/code/fbsource/[3e4ffd27ab80]/fbcode/caffe2/aten/src/ATen/TensorUtils.cpp?lines=330)
- `infer_size()` inside torch/standalone/util/ReshapeUtils.h
    - it corresponds to this aten implementation: [infer_size](https://www.internalfb.com/code/fbsource/[3e4ffd27ab80]/fbcode/caffe2/aten/src/ATen/InferSize.h?lines=20)

## Testing

I've written 6 tests in total.

1) `ReshapeAsView`: Reshape on a contiguous tensor that can be performed as a view.
2) `ReshapeWithCopy` : Reshape on a non-contiguous tensor, which should trigger a copy.
3) `ReshapeWithInferredDimension` : Reshape with an inferred dimension (-1).
4) `ReshapeAsViewCUDA` : Reshape on a contiguous tensor that can be performed as a view but on CUDA
5) `ReshapeWithCopyCUDA` : Reshape on a non-contiguous tensor, which should trigger a copy but on CUDA
6) `ReshapeWithCopyCUDAInt64` : Reshape on a non-contiguous tensor, which should trigger a copy and on CUDA and uses int64 datatype instead of float.

```
(pytorch-3.12) [serhatgundem@devvm2480.eag0 /data/users/serhatgundem/pytorch_fork (implement_reshape)]$ ./build/bin/test_aoti_standalone
Only one CUDA device detected. Disabling MultiCUDA tests
Note: Google Test filter = *-*_MultiCUDA
[==========] Running 28 tests from 5 test suites.
[----------] Global test environment set-up.
[----------] 7 tests from ReshapeTest
[ RUN      ] ReshapeTest.ReshapeAsView
[       OK ] ReshapeTest.ReshapeAsView (0 ms)
[ RUN      ] ReshapeTest.ReshapeWithCopy
[       OK ] ReshapeTest.ReshapeWithCopy (0 ms)
[ RUN      ] ReshapeTest.ReshapeWithInferredDimension
[       OK ] ReshapeTest.ReshapeWithInferredDimension (0 ms)
[ RUN      ] ReshapeTest.ReshapeMemberFunction
[       OK ] ReshapeTest.ReshapeMemberFunction (0 ms)
[ RUN      ] ReshapeTest.ReshapeAsViewCUDA
[       OK ] ReshapeTest.ReshapeAsViewCUDA (158 ms)
[ RUN      ] ReshapeTest.ReshapeWithCopyCUDA
[       OK ] ReshapeTest.ReshapeWithCopyCUDA (7 ms)
[ RUN      ] ReshapeTest.ReshapeWithCopyCUDAInt64
[       OK ] ReshapeTest.ReshapeWithCopyCUDAInt64 (0 ms)
[----------] 7 tests from ReshapeTest (167 ms total)

[----------] 4 tests from SlimTensorTest
[ RUN      ] SlimTensorTest.ResizeOpShrinkCPU
[       OK ] SlimTensorTest.ResizeOpShrinkCPU (0 ms)
[ RUN      ] SlimTensorTest.ResizeOpGrowCPU
[       OK ] SlimTensorTest.ResizeOpGrowCPU (0 ms)
[ RUN      ] SlimTensorTest.ResizeOpToZeroCPU
[       OK ] SlimTensorTest.ResizeOpToZeroCPU (0 ms)
[ RUN      ] SlimTensorTest.ResizeOpGrowCUDA
[       OK ] SlimTensorTest.ResizeOpGrowCUDA (0 ms)
[----------] 4 tests from SlimTensorTest (0 ms total)

[----------] 5 tests from ScalarTensorTest
[ RUN      ] ScalarTensorTest.ScalarTensorOp
[       OK ] ScalarTensorTest.ScalarTensorOp (0 ms)
[ RUN      ] ScalarTensorTest.ScalarTensorOpLong
[       OK ] ScalarTensorTest.ScalarTensorOpLong (0 ms)
[ RUN      ] ScalarTensorTest.ScalarTensorOpBoolTrue
[       OK ] ScalarTensorTest.ScalarTensorOpBoolTrue (0 ms)
[ RUN      ] ScalarTensorTest.ScalarTensorOpBoolFalse
[       OK ] ScalarTensorTest.ScalarTensorOpBoolFalse (0 ms)
[ RUN      ] ScalarTensorTest.ScalarTensorOpBoolTrueCUDA
[       OK ] ScalarTensorTest.ScalarTensorOpBoolTrueCUDA (5 ms)
[----------] 5 tests from ScalarTensorTest (5 ms total)

[----------] 6 tests from SlimTensorInternalTest
[ RUN      ] SlimTensorInternalTest.SetSizesContiguous
[       OK ] SlimTensorInternalTest.SetSizesContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.SetSizesAndStridesNonContiguous
[       OK ] SlimTensorInternalTest.SetSizesAndStridesNonContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.EmptyTensorRestride
[       OK ] SlimTensorInternalTest.EmptyTensorRestride (0 ms)
[ RUN      ] SlimTensorInternalTest.CopyFromContiguous
[       OK ] SlimTensorInternalTest.CopyFromContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.CopyFromNonContiguous
[       OK ] SlimTensorInternalTest.CopyFromNonContiguous (0 ms)
[ RUN      ] SlimTensorInternalTest.CopyFromNonContiguousCuda
[       OK ] SlimTensorInternalTest.CopyFromNonContiguousCuda (0 ms)
[----------] 6 tests from SlimTensorInternalTest (0 ms total)

[----------] 6 tests from TransposeTest
[ RUN      ] TransposeTest.TransposeOp
[       OK ] TransposeTest.TransposeOp (0 ms)
[ RUN      ] TransposeTest.TransposeNoOp
[       OK ] TransposeTest.TransposeNoOp (0 ms)
[ RUN      ] TransposeTest.TransposeOfTranspose
[       OK ] TransposeTest.TransposeOfTranspose (0 ms)
[ RUN      ] TransposeTest.TransposeMemberFunction
[       OK ] TransposeTest.TransposeMemberFunction (0 ms)
[ RUN      ] TransposeTest.TransposeMemberFunctionChaining
[       OK ] TransposeTest.TransposeMemberFunctionChaining (0 ms)
[ RUN      ] TransposeTest.TransposeOpCuda
[       OK ] TransposeTest.TransposeOpCuda (0 ms)
[----------] 6 tests from TransposeTest (0 ms total)

[----------] Global test environment tear-down
[==========] 28 tests from 5 test suites ran. (173 ms total)
[  PASSED  ] 28 tests.
```

cc: @desertfire @angelayi @yushangdi
