### PR TITLE
implement flash_attention

### DIFF
--- a/test/cpp/aoti_standalone/CMakeLists.txt
+++ b/test/cpp/aoti_standalone/CMakeLists.txt
@@ -3,9 +3,22 @@ set(AOTI_STANDALONE_TEST_ROOT ${TORCH_ROOT}/test/cpp/aoti_standalone)
 
 file(GLOB_RECURSE AOTI_STANDALONE_TEST_SRCS "${AOTI_STANDALONE_TEST_ROOT}/test*.cpp")
 
+# Add FlashAttention CUDA kernel files
+file(GLOB FLASH_ATTN_CUDA_SRCS
+  "${TORCH_ROOT}/third_party/flash-attention/csrc/flash_attn/src/flash_fwd_hdim*_sm80.cu"
+  "${TORCH_ROOT}/third_party/flash-attention/csrc/flash_attn/src/flash_fwd_split_hdim*_sm80.cu"
+)
+
 add_executable(test_aoti_standalone
   ${TORCH_ROOT}/test/cpp/common/main.cpp
   ${AOTI_STANDALONE_TEST_SRCS}
+  ${TORCH_ROOT}/torch/csrc/inductor/aoti_standalone/cuda/flash_attn/flash_api.cpp
+  ${FLASH_ATTN_CUDA_SRCS}
+)
+
+# Add FlashAttention include directories
+target_include_directories(test_aoti_standalone PRIVATE
+  ${TORCH_ROOT}/third_party/flash-attention/csrc/flash_attn/src
 )
 
 # TODO temporary until we can delete the old gtest polyfills.

--- a/test/cpp/aoti_standalone/test_flash_attention.cpp
+++ b/test/cpp/aoti_standalone/test_flash_attention.cpp
@@ -1,0 +1,323 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <torch/torch.h>
+#include <optional>
+
+// Guard for CUDA specific code and Flash Attention availability
+#if defined(USE_CUDA)
+#include <torch/csrc/inductor/aoti_standalone/cuda/flash_attn.h>
+#include <torch/csrc/inductor/aoti_standalone/factory.h>
+#include <torch/standalone/slim_tensor/slim_tensor.h>
+
+using ::testing::ElementsAreArray;
+using torch::standalone::SlimTensor;
+
+// Helper to convert a SlimTensor (potentially on CUDA) to a CPU at::Tensor for
+// easy comparison. It clones the data to ensure the at::Tensor owns its memory.
+at::Tensor slim_to_cpu_aten(SlimTensor* slim_tensor) {
+  if (!slim_tensor || slim_tensor->numel() == 0) {
+    // Return an empty tensor if the slim tensor is null or has no elements.
+    return at::empty(
+        {0},
+        at::TensorOptions().dtype(
+            slim_tensor ? slim_tensor->dtype() : at::kFloat));
+  }
+  SlimTensor slim_cpu = slim_tensor->to(at::kCPU);
+  return at::from_blob(
+             slim_cpu.data_ptr(),
+             slim_cpu.sizes(),
+             slim_cpu.strides(),
+             slim_cpu.dtype())
+      .clone(); // Crucial: clone to own the data
+}
+
+// Define a test fixture for convenience.
+// This sets up the CUDA device and tensor options for all tests in this suite.
+class ScaledDotProductFlashAttentionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!torch::cuda::is_available()) {
+      GTEST_SKIP() << "CUDA not available, skipping test suite.";
+    }
+    cuda_device_ = at::Device(at::kCUDA);
+    // FlashAttention is typically optimized for half precision.
+    options_ = at::TensorOptions().dtype(at::kHalf).device(cuda_device_);
+  }
+
+  // Helper to create both at::Tensor and its corresponding SlimTensor view.
+  void create_tensors(
+      const std::vector<int64_t>& q_shape,
+      const std::vector<int64_t>& kv_shape,
+      at::Tensor& at_q,
+      std::optional<SlimTensor>& slim_q,
+      at::Tensor& at_k,
+      std::optional<SlimTensor>& slim_k,
+      at::Tensor& at_v,
+      std::optional<SlimTensor>& slim_v) {
+    at_q = at::randn(q_shape, options_);
+    at_k = at::randn(kv_shape, options_);
+    at_v = at::randn(kv_shape, options_);
+
+    slim_q = torch::standalone::create_tensor_from_blob(
+        at_q.data_ptr(),
+        at_q.sizes(),
+        at_q.strides(),
+        options_.dtype().toScalarType(),
+        cuda_device_);
+    slim_k = torch::standalone::create_tensor_from_blob(
+        at_k.data_ptr(),
+        at_k.sizes(),
+        at_k.strides(),
+        options_.dtype().toScalarType(),
+        cuda_device_);
+    slim_v = torch::standalone::create_tensor_from_blob(
+        at_v.data_ptr(),
+        at_v.sizes(),
+        at_v.strides(),
+        options_.dtype().toScalarType(),
+        cuda_device_);
+  }
+
+  // The main verification function that runs both implementations and compares
+  // results.
+  void run_and_verify(
+      SlimTensor& slim_query,
+      SlimTensor& slim_key,
+      SlimTensor& slim_value,
+      const at::Tensor& at_query,
+      const at::Tensor& at_key,
+      const at::Tensor& at_value,
+      double dropout_p,
+      bool is_causal,
+      bool return_debug_mask,
+      std::optional<double> scale) {
+    // AOTI shim call
+    AtenTensorHandle ret0 = nullptr, ret1 = nullptr, ret2 = nullptr,
+                     ret3 = nullptr;
+    AtenTensorHandle ret6 = nullptr, ret7 = nullptr, ret8 = nullptr;
+    int64_t ret4 = 0, ret5 = 0;
+
+    AOTITorchError err = aoti_torch_cuda__scaled_dot_product_flash_attention(
+        reinterpret_cast<AtenTensorHandle>(&slim_query),
+        reinterpret_cast<AtenTensorHandle>(&slim_key),
+        reinterpret_cast<AtenTensorHandle>(&slim_value),
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        scale.has_value() ? &scale.value() : nullptr,
+        &ret0,
+        &ret1,
+        &ret2,
+        &ret3,
+        &ret4,
+        &ret5,
+        &ret6,
+        &ret7,
+        &ret8);
+
+    ASSERT_EQ(err, AOTI_TORCH_SUCCESS);
+
+    // PyTorch reference call
+    auto at_result_tuple = at::_scaled_dot_product_flash_attention(
+        at_query,
+        at_key,
+        at_value,
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        scale);
+
+    // Unpack results for comparison
+    auto at_attention = std::get<0>(at_result_tuple);
+    auto at_logsumexp = std::get<1>(at_result_tuple);
+
+    auto* slim_attention = reinterpret_cast<SlimTensor*>(ret0);
+    auto* slim_logsumexp = reinterpret_cast<SlimTensor*>(ret1);
+    ASSERT_NE(slim_attention, nullptr);
+    ASSERT_NE(slim_logsumexp, nullptr);
+
+    // 1. Compare metadata (sequence lengths)
+
+    ASSERT_EQ(ret4, std::get<4>(at_result_tuple));
+    ASSERT_EQ(ret5, std::get<5>(at_result_tuple));
+
+    // 2. Compare main output tensors (attention and logsumexp)
+    at::Tensor slim_attention_aten = slim_to_cpu_aten(slim_attention);
+    at::Tensor slim_logsumexp_aten = slim_to_cpu_aten(slim_logsumexp);
+    at::Tensor at_attention_cpu = at_attention.to(at::kCPU);
+    at::Tensor at_logsumexp_cpu = at_logsumexp.to(at::kCPU);
+
+    EXPECT_THAT(
+        slim_attention->sizes(), ElementsAreArray(at_attention.sizes()));
+    EXPECT_THAT(
+        slim_logsumexp->sizes(), ElementsAreArray(at_logsumexp.sizes()));
+
+    // Use allclose for float comparisons with a reasonable tolerance for flash
+    // attention.
+    ASSERT_TRUE(
+        at::allclose(slim_attention_aten, at_attention_cpu, 1e-3, 1e-3));
+    ASSERT_TRUE(
+        at::allclose(slim_logsumexp_aten, at_logsumexp_cpu, 1e-3, 1e-3));
+
+    // 3. Compare debug mask if requested
+    if (return_debug_mask) {
+      auto* slim_debug_mask = reinterpret_cast<SlimTensor*>(ret8);
+      auto at_debug_mask = std::get<8>(at_result_tuple);
+      ASSERT_NE(slim_debug_mask, nullptr);
+
+      EXPECT_THAT(
+          slim_debug_mask->sizes(), ElementsAreArray(at_debug_mask.sizes()));
+    }
+
+    // 4. Cleanup all returned tensor handles
+    delete reinterpret_cast<SlimTensor*>(ret0);
+    delete reinterpret_cast<SlimTensor*>(ret1);
+    delete reinterpret_cast<SlimTensor*>(ret2);
+    delete reinterpret_cast<SlimTensor*>(ret3);
+    delete reinterpret_cast<SlimTensor*>(ret6);
+    delete reinterpret_cast<SlimTensor*>(ret7);
+    delete reinterpret_cast<SlimTensor*>(ret8);
+  }
+
+  at::Device cuda_device_ = at::Device(at::kCPU);
+  at::TensorOptions options_;
+};
+
+// Test Case 1: Standard causal attention for language modeling.
+TEST_F(ScaledDotProductFlashAttentionTest, CausalMaskNoDropout) {
+  const int64_t batch_size = 4;
+  const int64_t num_heads = 8;
+  const int64_t seq_len = 512;
+  const int64_t head_dim = 64;
+
+  at::Tensor at_q, at_k, at_v;
+  std::optional<SlimTensor> slim_q, slim_k, slim_v;
+  create_tensors(
+      {batch_size, num_heads, seq_len, head_dim},
+      {batch_size, num_heads, seq_len, head_dim},
+      at_q,
+      slim_q,
+      at_k,
+      slim_k,
+      at_v,
+      slim_v);
+
+  run_and_verify(
+      *slim_q,
+      *slim_k,
+      *slim_v,
+      at_q,
+      at_k,
+      at_v,
+      0.0, // dropout_p (must be 0 for deterministic comparison)
+      true, // is_causal
+      false, // return_debug_mask
+      std::nullopt // scale
+  );
+}
+
+// Test Case 2: Non-causal attention (e.g., for an encoder) with a custom scale
+// factor.
+TEST_F(ScaledDotProductFlashAttentionTest, NonCausalWithScale) {
+  const int64_t batch_size = 2;
+  const int64_t num_heads = 4;
+  const int64_t q_seq_len = 256;
+  const int64_t kv_seq_len = 128;
+  const int64_t head_dim = 128;
+
+  at::Tensor at_q, at_k, at_v;
+  std::optional<SlimTensor> slim_q, slim_k, slim_v;
+  create_tensors(
+      {batch_size, num_heads, q_seq_len, head_dim},
+      {batch_size, num_heads, kv_seq_len, head_dim},
+      at_q,
+      slim_q,
+      at_k,
+      slim_k,
+      at_v,
+      slim_v);
+
+  const double custom_scale = 0.125;
+  run_and_verify(
+      *slim_q,
+      *slim_k,
+      *slim_v,
+      at_q,
+      at_k,
+      at_v,
+      0.0, // dropout_p
+      false, // is_causal
+      false, // return_debug_mask
+      custom_scale);
+}
+
+// Test Case 3: Causal attention with non-square sequence lengths, common in
+// text generation.
+TEST_F(ScaledDotProductFlashAttentionTest, CausalNonSquare) {
+  const int64_t batch_size = 2;
+  const int64_t num_heads = 8;
+  const int64_t q_seq_len = 1; // A single new token
+  const int64_t kv_seq_len = 1024; // Against a long key/value cache
+  const int64_t head_dim = 64;
+
+  at::Tensor at_q, at_k, at_v;
+  std::optional<SlimTensor> slim_q, slim_k, slim_v;
+  create_tensors(
+      {batch_size, num_heads, q_seq_len, head_dim},
+      {batch_size, num_heads, kv_seq_len, head_dim},
+      at_q,
+      slim_q,
+      at_k,
+      slim_k,
+      at_v,
+      slim_v);
+
+  run_and_verify(
+      *slim_q,
+      *slim_k,
+      *slim_v,
+      at_q,
+      at_k,
+      at_v,
+      0.0, // dropout_p
+      true, // is_causal
+      false, // return_debug_mask
+      std::nullopt);
+}
+
+// Test Case 4: Non-causal attention with non-square sequence lengths, common in
+// encoder-decoder architectures.
+TEST_F(ScaledDotProductFlashAttentionTest, NonCausalNonSquare) {
+  const int64_t batch_size = 3;
+  const int64_t num_heads = 6;
+  const int64_t q_seq_len = 512; // Query sequence length
+  const int64_t kv_seq_len = 256; // Key/Value sequence length
+  const int64_t head_dim = 64;
+
+  at::Tensor at_q, at_k, at_v;
+  std::optional<SlimTensor> slim_q, slim_k, slim_v;
+  create_tensors(
+      {batch_size, num_heads, q_seq_len, head_dim},
+      {batch_size, num_heads, kv_seq_len, head_dim},
+      at_q,
+      slim_q,
+      at_k,
+      slim_k,
+      at_v,
+      slim_v);
+
+  run_and_verify(
+      *slim_q,
+      *slim_k,
+      *slim_v,
+      at_q,
+      at_k,
+      at_v,
+      0.0, // dropout_p
+      false, // is_causal
+      false, // return_debug_mask
+      std::nullopt);
+}
+
+#endif // USE_CUDA

--- a/torch/csrc/inductor/aoti_standalone/cuda/flash_attn.h
+++ b/torch/csrc/inductor/aoti_standalone/cuda/flash_attn.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <torch/csrc/inductor/aoti_standalone/c/shim.h>
+#include <torch/standalone/cuda/flash_attn_template.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+using torch::standalone::SlimTensor;
+
+AOTITorchError aoti_torch_cuda__scaled_dot_product_flash_attention(
+    AtenTensorHandle query_handle,
+    AtenTensorHandle key_handle,
+    AtenTensorHandle value_handle,
+    double dropout_p,
+    int32_t is_causal,
+    int32_t return_debug_mask,
+    double* scale,
+    AtenTensorHandle* ret0,
+    AtenTensorHandle* ret1,
+    AtenTensorHandle* ret2,
+    AtenTensorHandle* ret3,
+    int64_t* ret4,
+    int64_t* ret5,
+    AtenTensorHandle* ret6,
+    AtenTensorHandle* ret7,
+    AtenTensorHandle* ret8) {
+  SlimTensor* query = reinterpret_cast<SlimTensor*>(query_handle);
+  SlimTensor* key = reinterpret_cast<SlimTensor*>(key_handle);
+  SlimTensor* value = reinterpret_cast<SlimTensor*>(value_handle);
+
+  std::optional<double> scale_opt =
+      scale ? std::optional<double>(*scale) : std::nullopt;
+
+  auto
+      [attention,
+       logsumexp,
+       cum_seq_q,
+       cum_seq_k,
+       max_seqlen_q,
+       max_seqlen_k,
+       philox_seed,
+       philox_offset,
+       debug_attn_mask] =
+          torch::standalone::_scaled_dot_product_flash_attention_cuda<
+              SlimTensor>(
+              *query,
+              *key,
+              *value,
+              dropout_p,
+              static_cast<bool>(is_causal),
+              static_cast<bool>(return_debug_mask),
+              scale_opt);
+
+  *ret0 =
+      reinterpret_cast<AtenTensorHandle>(new SlimTensor(std::move(attention)));
+  *ret1 =
+      reinterpret_cast<AtenTensorHandle>(new SlimTensor(std::move(logsumexp)));
+  *ret2 =
+      reinterpret_cast<AtenTensorHandle>(new SlimTensor(std::move(cum_seq_q)));
+  *ret3 =
+      reinterpret_cast<AtenTensorHandle>(new SlimTensor(std::move(cum_seq_k)));
+  *ret4 = max_seqlen_q;
+  *ret5 = max_seqlen_k;
+  *ret6 = reinterpret_cast<AtenTensorHandle>(
+      new SlimTensor(std::move(philox_seed)));
+  *ret7 = reinterpret_cast<AtenTensorHandle>(
+      new SlimTensor(std::move(philox_offset)));
+  *ret8 = reinterpret_cast<AtenTensorHandle>(
+      new SlimTensor(std::move(debug_attn_mask)));
+
+  return AOTI_TORCH_SUCCESS;
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/torch/csrc/inductor/aoti_standalone/cuda/flash_attn/flash_api.cpp
+++ b/torch/csrc/inductor/aoti_standalone/cuda/flash_attn/flash_api.cpp
@@ -1,0 +1,1398 @@
+/******************************************************************************
+ * Copyright (c) 2024, Tri Dao.
+ ******************************************************************************/
+#include <c10/core/DeviceType.h>
+#include <c10/core/ScalarType.h>
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <cstdint>
+#include <tuple>
+
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/numeric_types.h>
+
+#include <torch/csrc/inductor/aoti_standalone/cuda/flash_attn/flash_api.h>
+#include <torch/standalone/pad_template.h>
+#include <torch/standalone/slim_tensor/slim_tensor.h>
+
+#include <c10/util/Exception.h>
+
+#include <flash.h>
+#include <static_switch.h>
+
+#define CHECK_DEVICE(x) TORCH_CHECK(x.device().is_cuda(), #x " must be on CUDA")
+#define CHECK_SHAPE(x, ...)                         \
+  TORCH_CHECK(                                      \
+      x.sizes() == c10::IntArrayRef({__VA_ARGS__}), \
+      #x " must have shape (" #__VA_ARGS__ ")")
+#define CHECK_CONTIGUOUS(x) \
+  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+
+SlimTensor empty(c10::IntArrayRef size, const c10::TensorOptions& opts) {
+  return torch::standalone::create_empty_tensor(
+      size,
+      torch::standalone::compute_contiguous_strides(size),
+      opts.dtype().toScalarType(),
+      opts.device(),
+      0);
+}
+
+static cudaDeviceProp* getCurrentDeviceProperties() {
+  static thread_local cudaDeviceProp prop;
+  static thread_local bool initialized = false;
+
+  if (!initialized) {
+    int device;
+    cudaGetDevice(&device);
+    cudaGetDeviceProperties(&prop, device);
+    initialized = true;
+  }
+  return &prop;
+}
+
+SlimTensor pad(
+    const SlimTensor& t,
+    c10::IntArrayRef pad_dims,
+    const std::string& mode = "constant",
+    double value = 0.0) {
+  return torch::standalone::_pad(
+      t, pad_dims, mode, std::optional<double>(value));
+}
+
+SlimTensor zeros(c10::IntArrayRef size, const c10::TensorOptions& opts) {
+  return torch::standalone::zeros(size, opts);
+}
+SlimTensor reshape(const SlimTensor& t, c10::IntArrayRef shape) {
+  return torch::standalone::_reshape(t, shape);
+}
+
+void set_params_fprop(
+    FLASH_NAMESPACE::Flash_fwd_params& params,
+    bool is_causal,
+    // sizes
+    const size_t b,
+    const size_t seqlen_q,
+    const size_t seqlen_k,
+    const size_t seqlen_q_rounded,
+    const size_t seqlen_k_rounded,
+    const size_t h,
+    const size_t h_k,
+    const size_t d,
+    const size_t d_rounded,
+    // device pointers
+    const SlimTensor& q,
+    const SlimTensor& k,
+    const SlimTensor& v,
+    SlimTensor& out,
+    void* cu_seqlens_q_d,
+    void* cu_seqlens_k_d,
+    void* seqused_k,
+    void* p_d,
+    void* softmax_lse_d,
+    float p_dropout,
+    float softmax_scale,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    bool seqlenq_ngroups_swapped = false,
+    const bool unpadded_lse = false) {
+  // Reset the parameters
+  params = {};
+
+  params.is_bf16 = q.dtype() == c10::kBFloat16;
+
+  // Set the pointers and strides.
+  params.q_ptr = q.data_ptr();
+  params.k_ptr = k.data_ptr();
+  params.v_ptr = v.data_ptr();
+  // All stride are in elements, not bytes.
+  params.q_row_stride = q.stride(-3);
+  params.k_row_stride = k.stride(-3);
+  params.v_row_stride = v.stride(-3);
+  params.q_head_stride = q.stride(-2);
+  params.k_head_stride = k.stride(-2);
+  params.v_head_stride = v.stride(-2);
+  params.o_ptr = out.data_ptr();
+  params.o_row_stride = out.stride(-3);
+  params.o_head_stride = out.stride(-2);
+
+  if (cu_seqlens_q_d == nullptr) {
+    params.q_batch_stride = q.stride(0);
+    params.k_batch_stride = k.stride(0);
+    params.v_batch_stride = v.stride(0);
+    params.o_batch_stride = out.stride(0);
+    if (seqlenq_ngroups_swapped) {
+      params.q_batch_stride *= seqlen_q;
+      params.o_batch_stride *= seqlen_q;
+    }
+  }
+
+  params.cu_seqlens_q = static_cast<int*>(cu_seqlens_q_d);
+  params.cu_seqlens_k = static_cast<int*>(cu_seqlens_k_d);
+  params.seqused_k = static_cast<int*>(seqused_k);
+
+  // P = softmax(QK^T)
+  params.p_ptr = p_d;
+
+  // Softmax sum
+  params.softmax_lse_ptr = softmax_lse_d;
+
+  // Set the dimensions.
+  params.b = b;
+  params.h = h;
+  params.h_k = h_k;
+  params.h_h_k_ratio = h / h_k;
+  params.seqlen_q = seqlen_q;
+  params.seqlen_k = seqlen_k;
+  params.seqlen_q_rounded = seqlen_q_rounded;
+  params.seqlen_k_rounded = seqlen_k_rounded;
+  params.d = d;
+  params.d_rounded = d_rounded;
+
+// Set the different scale values.
+#ifdef FLASHATTENTION_DISABLE_SOFTCAP
+  TORCH_CHECK(
+      softcap <= 0.0, "This flash attention build does not support softcap.");
+#endif
+  if (softcap > 0.0) {
+    params.softcap = softmax_scale / softcap;
+    params.scale_softmax = softcap;
+    params.scale_softmax_log2 = softcap * M_LOG2E;
+  } else {
+    // Remove potential NaN
+    params.softcap = 0.0;
+    params.scale_softmax = softmax_scale;
+    params.scale_softmax_log2 = softmax_scale * M_LOG2E;
+  }
+
+  // Set this to probability of keeping an element to simplify things.
+  params.p_dropout = 1.f - p_dropout;
+  // Convert p from float to int so we don't have to convert the random uint to
+  // float to compare. [Minor] We want to round down since when we do the
+  // comparison we use <= instead of < params.p_dropout_in_uint =
+  // uint32_t(std::floor(params.p_dropout * 4294967295.0));
+  // params.p_dropout_in_uint16_t = uint16_t(std::floor(params.p_dropout *
+  // 65535.0));
+  params.p_dropout_in_uint8_t = uint8_t(std::floor(params.p_dropout * 255.0));
+  params.rp_dropout = 1.f / params.p_dropout;
+  params.scale_softmax_rp_dropout = params.rp_dropout * params.scale_softmax;
+  TORCH_CHECK(p_dropout < 1.f);
+#ifdef FLASHATTENTION_DISABLE_DROPOUT
+  TORCH_CHECK(
+      p_dropout == 0.0f,
+      "This flash attention build does not support dropout.");
+#endif
+
+  // Causal is the special case where window_size_right == 0 and
+  // window_size_left < 0. Local is the more general case where
+  // window_size_right >= 0 or window_size_left >= 0.
+  params.is_causal = is_causal;
+
+  if (!params.is_causal) {
+    if (window_size_left < 0 && window_size_right >= 0) {
+      window_size_left = seqlen_k;
+    }
+    if (window_size_left >= 0 && window_size_right < 0) {
+      window_size_right = seqlen_k;
+    }
+  }
+
+  params.window_size_left = window_size_left;
+  params.window_size_right = window_size_right;
+
+#ifdef FLASHATTENTION_DISABLE_LOCAL
+  TORCH_CHECK(
+      params.is_causal || (window_size_left < 0 && window_size_right < 0),
+      "This flash attention build does not support local attention.");
+#endif
+
+  params.is_seqlens_k_cumulative = true;
+
+#ifdef FLASHATTENTION_DISABLE_UNEVEN_K
+  TORCH_CHECK(
+      d == d_rounded,
+      "This flash attention build does not support headdim not being a multiple of 32.");
+#endif
+  params.unpadded_lse = unpadded_lse;
+  params.seqlenq_ngroups_swapped = seqlenq_ngroups_swapped;
+}
+
+void run_mha_fwd(
+    FLASH_NAMESPACE::Flash_fwd_params& params,
+    cudaStream_t stream,
+    bool force_split_kernel = false) {
+  FP16_SWITCH(!params.is_bf16, [&] {
+    HEADDIM_SWITCH(params.d, [&] {
+      BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+        if (params.num_splits <= 1 &&
+            !force_split_kernel) { // If we don't set it num_splits == 0
+          FLASH_NAMESPACE::run_mha_fwd_<elem_type, kHeadDim, Is_causal>(
+              params, stream);
+        } else {
+          FLASH_NAMESPACE::
+              run_mha_fwd_splitkv_dispatch<elem_type, kHeadDim, Is_causal>(
+                  params, stream);
+        }
+      });
+    });
+  });
+}
+
+// Find the number of splits that maximizes the occupancy. For example, if we
+// have batch * n_heads = 48 and we have 108 SMs, having 2 splits (efficiency =
+// 0.89) is better than having 3 splits (efficiency = 0.67). However, we also
+// don't want too many splits as that would incur more HBM reads/writes. So we
+// find the best efficiency, then find the smallest number of splits that gets
+// 85% of the best efficiency.
+inline int num_splits_heuristic(
+    int batch_nheads_mblocks,
+    int num_SMs,
+    int num_n_blocks,
+    int max_splits) {
+  // If we have enough to almost fill the SMs, then just use 1 split
+  if (batch_nheads_mblocks >= 0.8f * num_SMs) {
+    return 1;
+  }
+  max_splits = std::min({max_splits, num_SMs, num_n_blocks});
+  float max_efficiency = 0.f;
+  std::vector<float> efficiency;
+  efficiency.reserve(max_splits);
+  auto ceildiv = [](int a, int b) { return (a + b - 1) / b; };
+  // Some splits are not eligible. For example, if we have 64 blocks and choose
+  // 11 splits, we'll have 6 * 10 + 4 blocks. If we choose 12 splits, we'll have
+  // 6 * 11 + (-2) blocks (i.e. it's 11 splits anyway). So we check if the
+  // number of blocks per split is the same as the previous num_splits.
+  auto is_split_eligible = [&ceildiv, &num_n_blocks](int num_splits) {
+    return num_splits == 1 ||
+        ceildiv(num_n_blocks, num_splits) !=
+        ceildiv(num_n_blocks, num_splits - 1);
+  };
+  for (int num_splits = 1; num_splits <= max_splits; num_splits++) {
+    if (!is_split_eligible(num_splits)) {
+      efficiency.push_back(0.f);
+    } else {
+      float n_waves = float(batch_nheads_mblocks * num_splits) / num_SMs;
+      float eff = n_waves / ceil(n_waves);
+      // printf("num_splits = %d, eff = %f\n", num_splits, eff);
+      if (eff > max_efficiency) {
+        max_efficiency = eff;
+      }
+      efficiency.push_back(eff);
+    }
+  }
+  for (int num_splits = 1; num_splits <= max_splits; num_splits++) {
+    if (!is_split_eligible(num_splits)) {
+      continue;
+    }
+    if (efficiency[num_splits - 1] >= 0.85 * max_efficiency) {
+      // printf("num_splits chosen = %d\n", num_splits);
+      return num_splits;
+    }
+  }
+  return 1;
+}
+
+std::tuple<SlimTensor, SlimTensor> set_params_splitkv(
+    FLASH_NAMESPACE::Flash_fwd_params& params,
+    const int batch_size,
+    const int num_heads,
+    const int head_size,
+    const int max_seqlen_k,
+    const int max_seqlen_q,
+    const int head_size_rounded,
+    const float p_dropout,
+    const int num_splits,
+    cudaDeviceProp* dprops,
+    struct c10::TensorOptions opts) {
+  // This needs to match with run_mha_fwd_splitkv_dispatch
+  const int block_n = head_size <= 64 ? 256 : (head_size <= 128 ? 128 : 64);
+  const int num_n_blocks = (max_seqlen_k + block_n - 1) / block_n;
+  // Technically kBlockM = 64 only for the splitKV kernels, not the standard
+  // kernel. In any case we don't expect seqlen_q to be larger than 64 for
+  // inference.
+  const int num_m_blocks = (max_seqlen_q + 64 - 1) / 64;
+  params.num_splits = num_splits;
+  SlimTensor softmax_lse_accum =
+      torch::standalone::create_empty_tensor({}, {}, c10::kFloat, c10::kCUDA);
+  SlimTensor out_accum =
+      torch::standalone::create_empty_tensor({}, {}, c10::kFloat, c10::kCUDA);
+
+  if (p_dropout == 0.0f) { // SplitKV is not implemented for dropout
+    if (num_splits < 1) {
+      // We multiply number of SMs by 2 to hard-code the fact that we're using
+      // 128 threads per block.
+      params.num_splits = num_splits_heuristic(
+          batch_size * num_heads * num_m_blocks,
+          dprops->multiProcessorCount * 2,
+          num_n_blocks,
+          128);
+    }
+    if (params.num_splits > 1) {
+      softmax_lse_accum = empty(
+          {params.num_splits, batch_size, num_heads, max_seqlen_q},
+          opts.dtype(c10::kFloat));
+      out_accum = empty(
+          {params.num_splits,
+           batch_size,
+           num_heads,
+           max_seqlen_q,
+           head_size_rounded},
+          opts.dtype(c10::kFloat));
+      params.softmax_lseaccum_ptr = softmax_lse_accum.data_ptr();
+      params.oaccum_ptr = out_accum.data_ptr();
+    }
+    TORCH_CHECK(params.num_splits <= 128, "num_splits > 128 not supported");
+  }
+
+  return std::make_tuple(softmax_lse_accum, out_accum);
+}
+
+void set_params_alibi(
+    FLASH_NAMESPACE::Flash_fwd_params& params,
+    std::optional<SlimTensor>& alibi_slopes_,
+    int batch_size,
+    int num_heads) {
+#ifdef FLASHATTENTION_DISABLE_ALIBI
+  TORCH_CHECK(
+      !alibi_slopes_.has_value(),
+      "This flash attention build does not support alibi.");
+  params.alibi_slopes_ptr = nullptr;
+#else
+  if (alibi_slopes_.has_value()) {
+    auto alibi_slopes = alibi_slopes_.value();
+    TORCH_CHECK(
+        alibi_slopes.dtype() == c10::kFloat,
+        "ALiBi slopes must have dtype fp32");
+    CHECK_DEVICE(alibi_slopes);
+    TORCH_CHECK(
+        alibi_slopes.stride(-1) == 1,
+        "ALiBi slopes tensor must have contiguous last dimension");
+    TORCH_CHECK(
+        alibi_slopes.sizes() == c10::IntArrayRef({num_heads}) ||
+        alibi_slopes.sizes() == c10::IntArrayRef({batch_size, num_heads}));
+    params.alibi_slopes_ptr = alibi_slopes.data_ptr();
+    params.alibi_slopes_batch_stride =
+        alibi_slopes.dim() == 2 ? alibi_slopes.stride(0) : 0;
+  } else {
+    params.alibi_slopes_ptr = nullptr;
+  }
+#endif
+}
+
+std::tuple<
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor>
+mha_fwd(
+    const SlimTensor& q, // batch_size x seqlen_q x num_heads x head_size
+    const SlimTensor& k, // batch_size x seqlen_k x num_heads_k x head_size
+    const SlimTensor& v, // batch_size x seqlen_k x num_heads_k x head_size
+    std::optional<SlimTensor>&
+        out_, // batch_size x seqlen_q x num_heads x head_size
+    std::optional<SlimTensor>&
+        alibi_slopes_, // num_heads or batch_size x num_heads
+    const float p_dropout,
+    const float softmax_scale,
+    bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    const bool return_softmax) {
+  auto dprops = getCurrentDeviceProperties();
+  // bool is_sm75 = dprops->major == 7 && dprops->minor == 5;
+  bool is_sm8x = dprops->major == 8 && dprops->minor >= 0;
+  bool is_sm90 = dprops->major == 9 && dprops->minor == 0;
+  bool is_sm10x = dprops->major == 10 && dprops->minor >= 0;
+  bool is_sm120_or_sm121 = dprops->major == 12 && dprops->minor <= 1;
+  TORCH_CHECK(
+      is_sm120_or_sm121 || is_sm10x || is_sm90 || is_sm8x,
+      "FlashAttention only supports Ampere GPUs or newer.");
+  // We will support Turing in the near future
+  // TORCH_CHECK(is_sm90 || is_sm8x || is_sm75, "FlashAttention only supports
+  // Turing GPUs or newer.");
+
+  auto q_dtype = q.dtype();
+  TORCH_CHECK(
+      q_dtype == c10::kHalf || q_dtype == c10::kBFloat16,
+      "FlashAttention only support fp16 and bf16 data type");
+  if (q_dtype == c10::kBFloat16) {
+    TORCH_CHECK(
+        is_sm120_or_sm121 || is_sm10x || is_sm90 || is_sm8x,
+        "bfloat16 is only supported on Ampere GPUs or newer");
+  }
+  TORCH_CHECK(k.dtype() == q_dtype, "query and key must have the same dtype");
+  TORCH_CHECK(v.dtype() == q_dtype, "query and value must have the same dtype");
+
+  CHECK_DEVICE(q);
+  CHECK_DEVICE(k);
+  CHECK_DEVICE(v);
+
+  TORCH_CHECK(
+      q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+
+  const auto sizes = q.sizes();
+
+  const int batch_size = sizes[0];
+  int seqlen_q = sizes[1];
+  int num_heads = sizes[2];
+  const int head_size_og = sizes[3];
+  const int seqlen_k = k.size(1);
+  const int num_heads_k = k.size(2);
+
+  TORCH_CHECK(batch_size > 0, "batch size must be positive");
+  TORCH_CHECK(
+      head_size_og % 8 == 0,
+      "head_size must be a multiple of 8, this is ensured by padding!");
+  TORCH_CHECK(
+      head_size_og <= 256,
+      "FlashAttention forward only supports head dimension at most 256");
+  TORCH_CHECK(
+      num_heads % num_heads_k == 0,
+      "Number of heads in key/value must divide number of heads in query");
+
+  if (softcap > 0.f) {
+    TORCH_CHECK(
+        p_dropout == 0.f, "Softcapping does not support dropout for now");
+  }
+
+  if (window_size_left >= seqlen_k) {
+    window_size_left = -1;
+  }
+  if (window_size_right >= seqlen_k) {
+    window_size_right = -1;
+  }
+
+  if (is_causal) {
+    window_size_right = 0;
+  }
+
+  // Faster to transpose q from (b, 1, (nheads_kv ngroups), d) to (b, ngroups,
+  // nheads_kv, d) in this case H/t Daniel Haziza
+  const int seqlenq_ngroups_swapped = seqlen_q == 1 &&
+      num_heads > num_heads_k && window_size_left < 0 &&
+      window_size_right < 0 && p_dropout == 0.f && head_size_og % 8 == 0 &&
+      !alibi_slopes_.has_value();
+  const int ngroups = num_heads / num_heads_k;
+
+  SlimTensor temp_q = q;
+  if (seqlenq_ngroups_swapped) {
+    temp_q = q.reshape({batch_size, num_heads_k, ngroups, head_size_og})
+                 .transpose(1, 2);
+    seqlen_q = ngroups;
+    num_heads = num_heads_k;
+  }
+
+  CHECK_SHAPE(temp_q, batch_size, seqlen_q, num_heads, head_size_og);
+  CHECK_SHAPE(k, batch_size, seqlen_k, num_heads_k, head_size_og);
+  CHECK_SHAPE(v, batch_size, seqlen_k, num_heads_k, head_size_og);
+
+  SlimTensor q_padded = temp_q;
+  SlimTensor k_padded = k;
+  SlimTensor v_padded = v;
+
+  SlimTensor out =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  if (out_.has_value()) {
+    out = out_.value();
+    TORCH_CHECK(
+        out.dtype() == q_dtype, "Output must have the same dtype as inputs");
+    CHECK_DEVICE(out);
+    TORCH_CHECK(
+        out.stride(-1) == 1,
+        "Output tensor must have contiguous last dimension");
+    CHECK_SHAPE(out, batch_size, sizes[1], sizes[2], head_size_og);
+    if (seqlenq_ngroups_swapped) {
+      out = out.reshape({batch_size, num_heads_k, ngroups, head_size_og})
+                .transpose(1, 2);
+    }
+    CHECK_SHAPE(out, batch_size, seqlen_q, num_heads, head_size_og);
+    if (head_size_og % 8 != 0) {
+      out = torch::standalone::empty_like(q_padded);
+    }
+  } else {
+    out = torch::standalone::empty_like(q_padded);
+  }
+
+  auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
+  const int head_size = round_multiple(head_size_og, 8);
+  const int head_size_rounded =
+      round_multiple(head_size, 32) < 224 ? round_multiple(head_size, 32) : 256;
+  const int seqlen_q_rounded = round_multiple(seqlen_q, 128);
+  const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
+
+  // Otherwise the kernel will be launched from cuda:0 device
+  c10::cuda::CUDAGuard device_guard{q.device()};
+
+  auto opts = c10::TensorOptions().dtype(q.dtype()).device(q.device());
+
+  auto softmax_lse =
+      empty({batch_size, num_heads, seqlen_q}, opts.dtype(c10::kFloat));
+
+  SlimTensor p =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  // Only return softmax if there's dropout to reduce compilation time
+  if (return_softmax) {
+    TORCH_CHECK(
+        p_dropout > 0.0f,
+        "return_softmax is only supported when p_dropout > 0.0");
+    p = empty(
+        {batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded}, opts);
+  }
+
+  FLASH_NAMESPACE::Flash_fwd_params params;
+
+  set_params_fprop(
+      params,
+      is_causal,
+      batch_size,
+      seqlen_q,
+      seqlen_k,
+      seqlen_q_rounded,
+      seqlen_k_rounded,
+      num_heads,
+      num_heads_k,
+      head_size,
+      head_size_rounded,
+      q_padded,
+      k_padded,
+      v_padded,
+      out,
+      /*cu_seqlens_q_d=*/nullptr,
+      /*cu_seqlens_k_d=*/nullptr,
+      /*seqused_k=*/nullptr,
+      return_softmax ? p.data_ptr() : nullptr,
+      softmax_lse.data_ptr(),
+      p_dropout,
+      softmax_scale,
+      window_size_left,
+      window_size_right,
+      softcap);
+
+  // Keep references to these tensors to extend their lifetime
+  auto [softmax_lse_accum, out_accum] = set_params_splitkv(
+      params,
+      batch_size,
+      num_heads,
+      head_size,
+      seqlen_k,
+      seqlen_q,
+      head_size_rounded,
+      p_dropout,
+      /*num_splits*/ 0,
+      dprops,
+      opts);
+
+  // See [Note] BC breaking change to flash seed/offset
+  auto rng_state =
+      empty({2}, c10::TensorOptions().dtype(c10::kUInt64).device(c10::kCUDA));
+  auto _unused =
+      empty({}, c10::TensorOptions().dtype(c10::kUInt64).device(c10::kCUDA));
+  if (p_dropout > 0.0) {
+    TORCH_CHECK(
+        false, "Standalone Flash Attention does not support dropout yet.");
+  }
+
+  set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
+
+  if (seqlen_k > 0) {
+    auto stream = c10::cuda::getCurrentCUDAStream().stream();
+    run_mha_fwd(params, stream);
+  } else {
+    // If seqlen_k == 0, then we have an empty tensor. We need to set the output
+    // to 0.
+    out.zero_();
+    softmax_lse.fill_(std::numeric_limits<float>::infinity());
+  }
+
+  if (seqlenq_ngroups_swapped) {
+    out = out.transpose(1, 2).reshape(
+        {batch_size, 1, num_heads_k * seqlen_q, head_size_og});
+    q_padded = q_padded.transpose(1, 2).reshape(
+        {batch_size, 1, num_heads_k * seqlen_q, head_size_og});
+    softmax_lse = softmax_lse.reshape({batch_size, num_heads_k * seqlen_q, 1});
+  }
+
+  return {
+      out, q_padded, k_padded, v_padded, softmax_lse, rng_state, _unused, p};
+}
+
+std::tuple<
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor>
+mha_varlen_fwd(
+    const SlimTensor&
+        q, // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+    const SlimTensor& k, // total_k x num_heads_k x head_size, total_k :=
+                         // \sum_{i=0}^{b} s_i or num_blocks x page_block_size x
+                         // num_heads_k x head_size if there's a block_table.
+    const SlimTensor& v, // total_k x num_heads_k x head_size, total_k :=
+                         // \sum_{i=0}^{b} s_i or num_blocks x page_block_size x
+                         // num_heads_k x head_size if there's a block_table.
+    std::optional<SlimTensor>&
+        out_, // total_q x num_heads x head_size, total_k := \sum_{i=0}^{b} s_i
+    const SlimTensor& cu_seqlens_q, // b+1
+    const SlimTensor& cu_seqlens_k, // b+1
+    std::optional<SlimTensor>&
+        seqused_k, // b. If given, only this many elements of each batch
+                   // element's keys are used.
+    std::optional<SlimTensor>&
+        block_table_, // batch_size x max_num_blocks_per_seq
+    std::optional<SlimTensor>& alibi_slopes_, // num_heads or b x num_heads
+    int max_seqlen_q,
+    const int max_seqlen_k,
+    const float p_dropout,
+    const float softmax_scale,
+    const bool zero_tensors,
+    bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    const bool return_softmax) {
+  auto dprops = getCurrentDeviceProperties();
+  // bool is_sm75 = dprops->major == 7 && dprops->minor == 5;
+  bool is_sm8x = dprops->major == 8 && dprops->minor >= 0;
+  bool is_sm90 = dprops->major == 9 && dprops->minor == 0;
+  bool is_sm10x = dprops->major == 10 && dprops->minor >= 0;
+  bool is_sm120_or_sm121 = dprops->major == 12 && dprops->minor <= 1;
+  TORCH_CHECK(
+      is_sm120_or_sm121 || is_sm10x || is_sm90 || is_sm8x,
+      "FlashAttention only supports Ampere GPUs or newer.");
+  // We will support Turing in the near future
+  // TORCH_CHECK(is_sm90 || is_sm8x || is_sm75, "FlashAttention only supports
+  // Turing GPUs or newer.");
+
+  auto q_dtype = q.dtype();
+  TORCH_CHECK(
+      q_dtype == c10::kHalf || q_dtype == c10::kBFloat16,
+      "FlashAttention only support fp16 and bf16 data type");
+  if (q_dtype == c10::kBFloat16) {
+    TORCH_CHECK(
+        is_sm120_or_sm121 || is_sm10x || is_sm90 || is_sm8x,
+        "bfloat16 is only supported on Ampere GPUs or newer");
+  }
+  TORCH_CHECK(k.dtype() == q_dtype, "query and key must have the same dtype");
+  TORCH_CHECK(v.dtype() == q_dtype, "query and value must have the same dtype");
+  TORCH_CHECK(
+      cu_seqlens_q.dtype() == c10::kInt, "cu_seqlens_q must have dtype int32");
+  TORCH_CHECK(
+      cu_seqlens_k.dtype() == c10::kInt, "cu_seqlens_k must have dtype int32");
+
+  CHECK_DEVICE(q);
+  CHECK_DEVICE(k);
+  CHECK_DEVICE(v);
+  CHECK_DEVICE(cu_seqlens_q);
+  CHECK_DEVICE(cu_seqlens_k);
+
+  SlimTensor block_table =
+      torch::standalone::create_empty_tensor({}, {}, c10::kInt, c10::kCUDA);
+  const bool paged_KV = block_table_.has_value();
+  if (paged_KV) {
+    block_table = block_table_.value();
+    CHECK_DEVICE(block_table);
+    TORCH_CHECK(
+        block_table.dtype() == c10::kInt,
+        "block_table must have dtype torch.int32");
+    TORCH_CHECK(
+        block_table.stride(-1) == 1,
+        "block_table must have contiguous last dimension");
+  }
+
+  TORCH_CHECK(
+      q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+  CHECK_CONTIGUOUS(cu_seqlens_q);
+  CHECK_CONTIGUOUS(cu_seqlens_k);
+
+  const auto sizes = q.sizes();
+
+  const int batch_size = cu_seqlens_q.numel() - 1;
+  int num_heads = sizes[1];
+  const int head_size_og = sizes[2];
+  const int num_heads_k = paged_KV ? k.size(2) : k.size(1);
+
+  if (softcap > 0.f) {
+    TORCH_CHECK(
+        p_dropout == 0.f, "Softcapping does not support dropout for now");
+  }
+
+  const int max_num_blocks_per_seq = !paged_KV ? 0 : block_table.size(1);
+  const int num_blocks = !paged_KV ? 0 : k.size(0);
+  const int page_block_size = !paged_KV ? 1 : k.size(1);
+  TORCH_CHECK(
+      !paged_KV || page_block_size % 256 == 0,
+      "Paged KV cache block size must be divisible by 256");
+
+  if (max_seqlen_q == 1 && !alibi_slopes_.has_value()) {
+    is_causal = false;
+  } // causal=true is the same as causal=false in this case
+  if (is_causal) {
+    window_size_right = 0;
+  }
+
+  void* cu_seqlens_q_d = cu_seqlens_q.data_ptr();
+
+  // Faster to transpose q from (b, 1, (nheads_kv ngroups), d) to (b, ngroups,
+  // nheads_kv, d) in this case H/t Daniel Haziza
+  const int seqlenq_ngroups_swapped = max_seqlen_q == 1 &&
+      num_heads > num_heads_k && window_size_left < 0 &&
+      window_size_right < 0 && p_dropout == 0.f && head_size_og % 8 == 0 &&
+      !alibi_slopes_.has_value();
+  SlimTensor temp_q = q;
+  const int ngroups = num_heads / num_heads_k;
+  if (seqlenq_ngroups_swapped) {
+    temp_q = q.reshape({batch_size, num_heads_k, ngroups, head_size_og})
+                 .transpose(1, 2)
+                 .reshape({batch_size * ngroups, num_heads_k, head_size_og});
+    max_seqlen_q = ngroups;
+    num_heads = num_heads_k;
+    cu_seqlens_q_d = nullptr;
+  }
+
+  const int total_q = temp_q.sizes()[0];
+
+  TORCH_CHECK(batch_size > 0, "batch size must be positive");
+  TORCH_CHECK(
+      head_size_og <= 256,
+      "FlashAttention forward only supports head dimension at most 256");
+  TORCH_CHECK(
+      num_heads % num_heads_k == 0,
+      "Number of heads in key/value must divide number of heads in query");
+  TORCH_CHECK(
+      head_size_og % 8 == 0,
+      "head_size must be a multiple of 8, this is ensured by padding!")
+
+  if (window_size_left >= max_seqlen_k) {
+    window_size_left = -1;
+  }
+  if (window_size_right >= max_seqlen_k) {
+    window_size_right = -1;
+  }
+
+  CHECK_SHAPE(temp_q, total_q, num_heads, head_size_og);
+  if (!paged_KV) {
+    const int total_k = k.size(0);
+    CHECK_SHAPE(k, total_k, num_heads_k, head_size_og);
+    CHECK_SHAPE(v, total_k, num_heads_k, head_size_og);
+  } else {
+    CHECK_SHAPE(k, num_blocks, page_block_size, num_heads_k, head_size_og);
+    CHECK_SHAPE(v, num_blocks, page_block_size, num_heads_k, head_size_og);
+    CHECK_SHAPE(block_table, batch_size, max_num_blocks_per_seq);
+  }
+  CHECK_SHAPE(cu_seqlens_q, batch_size + 1);
+  CHECK_SHAPE(cu_seqlens_k, batch_size + 1);
+  if (seqused_k.has_value()) {
+    auto seqused_k_ = seqused_k.value();
+    TORCH_CHECK(
+        seqused_k_.dtype() == c10::kInt, "seqused_k must have dtype int32");
+    TORCH_CHECK(
+        seqused_k_.device().is_cuda(), "seqused_k must be on CUDA device");
+    TORCH_CHECK(seqused_k_.is_contiguous(), "seqused_k must be contiguous");
+    CHECK_SHAPE(seqused_k_, batch_size);
+  }
+
+  SlimTensor q_padded = temp_q;
+  SlimTensor k_padded = k;
+  SlimTensor v_padded = v;
+
+  SlimTensor out =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  if (out_.has_value()) {
+    out = out_.value();
+    TORCH_CHECK(
+        out.dtype() == q_dtype, "Output must have the same dtype as inputs");
+    CHECK_DEVICE(out);
+    TORCH_CHECK(
+        out.stride(-1) == 1,
+        "Output tensor must have contiguous last dimension");
+    CHECK_SHAPE(out, sizes[0], sizes[1], head_size_og);
+    if (seqlenq_ngroups_swapped) {
+      out = out.reshape({batch_size, num_heads_k, ngroups, head_size_og})
+                .transpose(1, 2)
+                .reshape({batch_size * ngroups, num_heads_k, head_size_og});
+    }
+    if (head_size_og % 8 != 0) {
+      out = torch::standalone::empty_like(q_padded);
+    }
+  } else {
+    out = torch::standalone::empty_like(q_padded);
+  }
+
+  auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
+  const int head_size = round_multiple(head_size_og, 8);
+  const int head_size_rounded =
+      round_multiple(head_size, 32) < 224 ? round_multiple(head_size, 32) : 256;
+  const int seqlen_q_rounded = round_multiple(max_seqlen_q, 128);
+  const int seqlen_k_rounded = round_multiple(max_seqlen_k, 128);
+
+  // Otherwise the kernel will be launched from cuda:0 device
+  // Cast to char to avoid compiler warning about narrowing
+  c10::cuda::CUDAGuard device_guard{q.device()};
+
+  auto opts = c10::TensorOptions().dtype(q.dtype()).device(q.device());
+
+  auto softmax_lse = empty({num_heads, total_q}, opts.dtype(c10::kFloat));
+  SlimTensor p =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  // Only return softmax if there's dropout to reduce compilation time
+  if (return_softmax) {
+    TORCH_CHECK(
+        p_dropout > 0.0f,
+        "return_softmax is only supported when p_dropout > 0.0");
+    p = empty(
+        {batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded}, opts);
+  }
+
+  if (zero_tensors) {
+    out.zero_();
+    softmax_lse.fill_(-std::numeric_limits<float>::infinity());
+    if (return_softmax) {
+      p.zero_();
+    }
+  }
+
+  FLASH_NAMESPACE::Flash_fwd_params params;
+  set_params_fprop(
+      params,
+      is_causal,
+      batch_size,
+      max_seqlen_q,
+      max_seqlen_k,
+      seqlen_q_rounded,
+      seqlen_k_rounded,
+      num_heads,
+      num_heads_k,
+      head_size,
+      head_size_rounded,
+      q_padded,
+      k_padded,
+      v_padded,
+      out,
+      cu_seqlens_q_d,
+      cu_seqlens_k.data_ptr(),
+      seqused_k.has_value() ? seqused_k.value().data_ptr() : nullptr,
+      return_softmax ? p.data_ptr() : nullptr,
+      softmax_lse.data_ptr(),
+      p_dropout,
+      softmax_scale,
+      window_size_left,
+      window_size_right,
+      softcap,
+      seqlenq_ngroups_swapped,
+      /*unpadded_lse*/ true);
+  params.total_q = total_q;
+  if (paged_KV) {
+    params.block_table = static_cast<int*>(block_table.data_ptr());
+    params.block_table_batch_stride = block_table.stride(0);
+    params.k_batch_stride = k_padded.stride(0);
+    params.v_batch_stride = v_padded.stride(0);
+  }
+  params.page_block_size = page_block_size;
+  // Keep references to these tensors to extend their lifetime
+  SlimTensor softmax_lse_accum =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  SlimTensor out_accum =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  if (seqlenq_ngroups_swapped) {
+    // Only apply split-k for decoding
+    std::tie(softmax_lse_accum, out_accum) = set_params_splitkv(
+        params,
+        batch_size,
+        num_heads,
+        head_size,
+        max_seqlen_k,
+        max_seqlen_q,
+        head_size_rounded,
+        p_dropout,
+        /*num_splits*/ 0,
+        dprops,
+        opts);
+  }
+
+  // [Note] BC breaking change to flash seed/offset
+  // Previously: Used separate tensors for philox_seed and philox_offset,
+  // sometimes on CPU, sometimes on CUDA FlashAttention change: Now uses a
+  // single uint64_t[2] tensor on device containing both seed and offset
+  // Implementation: Renamed "seed" → "rng_state" (contains both seed+offset)
+  // and "offset" → "_unused"
+  auto rng_state = empty({2}, c10::dtype(c10::kUInt64).device(c10::kCUDA));
+  auto _unused = empty({}, c10::dtype(c10::kUInt64).device(c10::kCUDA));
+  // #ifndef TORCH_STANDALONE
+  //   if (p_dropout > 0.0) {
+  //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+  //         std::nullopt, at::cuda::detail::getDefaultCUDAGenerator());
+  //     // number of times random will be generated per thread, to offset
+  //     philox
+  //     // counter in thc random state We use a custom RNG that increases the
+  //     offset
+  //     // by batch_size * nheads * 32.
+  //     int64_t counter_offset = params.b * params.h * 32;
+  //     // See Note [Acquire lock when using random generators]
+  //     std::lock_guard<std::mutex> lock(gen->mutex_);
+
+  //     // TODO: move this PhiloxCudaState out of at namespace
+  //     at::PhiloxCudaState philox_state =
+  //     gen->philox_cuda_state(counter_offset); rng_state = Traits::empty(
+  //         {2}, c10::TensorOptions().dtype(c10::kUInt64).device(c10::kCUDA));
+  //     params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
+  //     params.philox_args = philox_state;
+  //   }
+  // #endif // TORCH_STANDALONE
+  set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
+
+  if (max_seqlen_k > 0) {
+    auto stream = c10::cuda::getCurrentCUDAStream().stream();
+    run_mha_fwd(params, stream, paged_KV);
+  } else {
+    // If seqlen_k == 0, then we have an empty tensor. We need to set the output
+    // to 0.
+    out.zero_();
+    softmax_lse.fill_(std::numeric_limits<float>::infinity());
+  }
+
+  if (seqlenq_ngroups_swapped) {
+    std::array<int64_t, 4> size_before = {
+        batch_size, max_seqlen_q, num_heads_k, head_size_og};
+    std::array<int64_t, 3> size_after = {
+        batch_size, num_heads_k * max_seqlen_q, head_size_og};
+    out = out.reshape(size_before).transpose(1, 2).reshape(size_after);
+    q_padded =
+        q_padded.reshape(size_before).transpose(1, 2).reshape(size_after);
+    softmax_lse = softmax_lse.reshape({num_heads * max_seqlen_q, batch_size});
+  }
+
+  return {
+      out, q_padded, k_padded, v_padded, softmax_lse, rng_state, _unused, p};
+}
+
+std::tuple<SlimTensor, SlimTensor> mha_fwd_kvcache(
+    SlimTensor& q, // batch_size x seqlen_q x num_heads x head_size
+    const SlimTensor&
+        kcache, // batch_size_c x seqlen_k x num_heads_k x head_size or
+                // num_blocks x page_block_size x num_heads_k x head_size if
+                // there's a block_table.
+    const SlimTensor&
+        vcache, // batch_size_c x seqlen_k x num_heads_k x head_size or
+                // num_blocks x page_block_size x num_heads_k x head_size if
+                // there's a block_table.
+    std::optional<const SlimTensor>&
+        k_, // batch_size x seqlen_knew x num_heads_k x head_size
+    std::optional<const SlimTensor>&
+        v_, // batch_size x seqlen_knew x num_heads_k x head_size
+    std::optional<const SlimTensor>& seqlens_k_, // batch_size
+    std::optional<const SlimTensor>&
+        rotary_cos_, // seqlen_ro x (rotary_dim / 2)
+    std::optional<const SlimTensor>&
+        rotary_sin_, // seqlen_ro x (rotary_dim / 2)
+    std::optional<const SlimTensor>&
+        cache_batch_idx_, // indices to index into the KV cache
+    std::optional<SlimTensor>&
+        block_table_, // batch_size x max_num_blocks_per_seq
+    std::optional<SlimTensor>&
+        alibi_slopes_, // num_heads or batch_size x num_heads
+    std::optional<SlimTensor>&
+        out_, // batch_size x seqlen_q x num_heads x head_size
+    const float softmax_scale,
+    bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    bool is_rotary_interleaved, // if true, rotary combines indices 0 & 1, else
+                                // indices 0 & rotary_dim / 2
+    int num_splits) {
+  auto dprops = getCurrentDeviceProperties();
+  // bool is_sm75 = dprops->major == 7 && dprops->minor == 5;
+  bool is_sm8x = dprops->major == 8 && dprops->minor >= 0;
+  bool is_sm90 = dprops->major == 9 && dprops->minor == 0;
+  bool is_sm10x = dprops->major == 10 && dprops->minor >= 0;
+  bool is_sm120_or_sm121 = dprops->major == 12 && dprops->minor <= 1;
+  TORCH_CHECK(
+      is_sm120_or_sm121 || is_sm10x || is_sm90 || is_sm8x,
+      "FlashAttention only supports Ampere GPUs or newer.");
+  // We will support Turing in the near future
+  // TORCH_CHECK(is_sm90 || is_sm8x || is_sm75, "FlashAttention only supports
+  // Turing GPUs or newer.");
+
+  auto q_dtype = q.dtype();
+  TORCH_CHECK(
+      q_dtype == c10::kHalf || q_dtype == c10::kBFloat16,
+      "FlashAttention only support fp16 and bf16 data type");
+  if (q_dtype == c10::kBFloat16) {
+    TORCH_CHECK(
+        is_sm120_or_sm121 || is_sm10x || is_sm90 || is_sm8x,
+        "bfloat16 is only supported on Ampere GPUs or newer");
+  }
+  TORCH_CHECK(
+      kcache.dtype() == q_dtype, "query and key must have the same dtype");
+  TORCH_CHECK(
+      vcache.dtype() == q_dtype, "query and value must have the same dtype");
+
+  CHECK_DEVICE(q);
+  CHECK_DEVICE(kcache);
+  CHECK_DEVICE(vcache);
+
+  TORCH_CHECK(
+      q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      kcache.stride(-1) == 1,
+      "Input tensor must have contiguous last dimension");
+  TORCH_CHECK(
+      vcache.stride(-1) == 1,
+      "Input tensor must have contiguous last dimension");
+
+  SlimTensor block_table =
+      torch::standalone::create_empty_tensor({}, {}, c10::kInt, c10::kCUDA);
+  const bool paged_KV = block_table_.has_value();
+  if (paged_KV) {
+    TORCH_CHECK(
+        !cache_batch_idx_.has_value(),
+        "Paged KVcache does not support cache_batch_idx");
+    block_table = block_table_.value();
+    CHECK_DEVICE(block_table);
+    TORCH_CHECK(
+        block_table.dtype() == c10::kInt,
+        "block_table must have dtype torch.int32");
+    TORCH_CHECK(
+        block_table.stride(-1) == 1,
+        "block_table must have contiguous last dimension");
+  }
+
+  const auto sizes = q.sizes();
+
+  const int batch_size = sizes[0];
+  int seqlen_q = sizes[1];
+  int num_heads = sizes[2];
+  const int head_size_og = sizes[3];
+
+  const int max_num_blocks_per_seq = !paged_KV ? 0 : block_table.size(1);
+  const int num_blocks = !paged_KV ? 0 : kcache.size(0);
+  const int page_block_size = !paged_KV ? 1 : kcache.size(1);
+  TORCH_CHECK(
+      !paged_KV || page_block_size % 256 == 0,
+      "Paged KV cache block size must be divisible by 256");
+  const int seqlen_k =
+      !paged_KV ? kcache.size(1) : max_num_blocks_per_seq * page_block_size;
+  const int num_heads_k = kcache.size(2);
+  const int batch_size_c = !paged_KV ? kcache.size(0) : batch_size;
+  TORCH_CHECK(batch_size > 0, "batch size must be postive");
+  TORCH_CHECK(
+      head_size_og <= 256,
+      "FlashAttention forward only supports head dimension at most 256");
+  TORCH_CHECK(
+      num_heads % num_heads_k == 0,
+      "Number of heads in key/value must divide number of heads in query");
+
+  // causal=true is the same as causal=false in this case
+  if (seqlen_q == 1 && !alibi_slopes_.has_value()) {
+    is_causal = false;
+  }
+  if (is_causal) {
+    window_size_right = 0;
+  }
+
+  // Faster to transpose q from (b, 1, (nheads_kv ngroups), d) to (b, ngroups,
+  // nheads_kv, d) in this case H/t Daniel Haziza
+  const int seqlenq_ngroups_swapped = seqlen_q == 1 &&
+      num_heads > num_heads_k && window_size_left < 0 &&
+      window_size_right < 0 && head_size_og % 8 == 0 &&
+      !alibi_slopes_.has_value();
+  if (seqlenq_ngroups_swapped) {
+    const int ngroups = num_heads / num_heads_k;
+    q = q.reshape({batch_size, num_heads_k, ngroups, head_size_og})
+            .transpose(1, 2);
+    seqlen_q = ngroups;
+    num_heads = num_heads_k;
+  }
+
+  if (window_size_left >= seqlen_k) {
+    window_size_left = -1;
+  }
+  if (window_size_right >= seqlen_k) {
+    window_size_right = -1;
+  }
+
+  CHECK_SHAPE(q, batch_size, seqlen_q, num_heads, head_size_og);
+  if (!paged_KV) {
+    CHECK_SHAPE(kcache, batch_size_c, seqlen_k, num_heads_k, head_size_og);
+    CHECK_SHAPE(vcache, batch_size_c, seqlen_k, num_heads_k, head_size_og);
+  } else {
+    CHECK_SHAPE(kcache, num_blocks, page_block_size, num_heads_k, head_size_og);
+    CHECK_SHAPE(vcache, num_blocks, page_block_size, num_heads_k, head_size_og);
+    CHECK_SHAPE(block_table, batch_size, max_num_blocks_per_seq);
+  }
+
+  SlimTensor q_padded =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  SlimTensor kcache_padded = torch::standalone::create_empty_tensor(
+      {}, {}, kcache.dtype(), kcache.device());
+  SlimTensor vcache_padded = torch::standalone::create_empty_tensor(
+      {}, {}, vcache.dtype(), vcache.device());
+  if (head_size_og % 8 != 0) {
+    q_padded = pad(q, {0, 8 - head_size_og % 8});
+    kcache_padded = pad(kcache, {0, 8 - head_size_og % 8});
+    vcache_padded = pad(vcache, {0, 8 - head_size_og % 8});
+    // q_padded = at::nn::functional::pad(q,
+    // at::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
+    // kcache_padded = at::nn::functional::pad(kcache,
+    // at::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
+    // vcache_padded = at::nn::functional::pad(vcache,
+    // at::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
+  } else {
+    q_padded = q;
+    kcache_padded = kcache;
+    vcache_padded = vcache;
+  }
+
+  SlimTensor out =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  if (out_.has_value()) {
+    out = out_.value();
+    TORCH_CHECK(
+        out.dtype() == q_dtype, "Output must have the same dtype as inputs");
+    CHECK_DEVICE(out);
+    TORCH_CHECK(
+        out.stride(-1) == 1,
+        "Output tensor must have contiguous last dimension");
+    CHECK_SHAPE(out, batch_size, seqlen_q, num_heads, head_size_og);
+    if (head_size_og % 8 != 0) {
+      out = torch::standalone::empty_like(q_padded);
+    }
+  } else {
+    out = torch::standalone::empty_like(q_padded);
+  }
+
+  auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
+  const int head_size = round_multiple(head_size_og, 8);
+  const int head_size_rounded =
+      round_multiple(head_size, 32) < 224 ? round_multiple(head_size, 32) : 256;
+  const int seqlen_q_rounded = round_multiple(seqlen_q, 128);
+  const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
+
+  // Otherwise the kernel will be launched from cuda:0 device
+  // Cast to char to avoid compiler warning about narrowing
+  c10::cuda::CUDAGuard device_guard{q.device()};
+
+  auto opts = c10::TensorOptions().dtype(q.dtype()).device(q.device());
+
+  auto softmax_lse =
+      empty({batch_size, num_heads, seqlen_q}, opts.dtype(c10::kFloat));
+
+  FLASH_NAMESPACE::Flash_fwd_params params;
+  set_params_fprop(
+      params,
+      is_causal,
+      batch_size,
+      seqlen_q,
+      seqlen_k,
+      seqlen_q_rounded,
+      seqlen_k_rounded,
+      num_heads,
+      num_heads_k,
+      head_size,
+      head_size_rounded,
+      q_padded,
+      kcache_padded,
+      vcache_padded,
+      out,
+      /*cu_seqlens_q_d=*/nullptr,
+      /*cu_seqlens_k_d=*/nullptr,
+      /*seqused_k=*/nullptr,
+      /*p_ptr=*/nullptr,
+      softmax_lse.data_ptr(),
+      /*p_dropout=*/0.f,
+      softmax_scale,
+      window_size_left,
+      window_size_right,
+      softcap);
+
+  SlimTensor k =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  SlimTensor v =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  SlimTensor k_padded =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  SlimTensor v_padded =
+      torch::standalone::create_empty_tensor({}, {}, q.dtype(), q.device());
+  if (k_.has_value()) {
+    TORCH_CHECK(
+        v_.has_value(), "If key is supplied, value must also be passed in");
+    TORCH_CHECK(
+        seqlens_k_.has_value(),
+        "If key is supplied, seqlens_k must also be passed in");
+    TORCH_CHECK(
+        seqlen_q <= seqlen_k,
+        "If key is supplied, it must have seqlen <= the seqlen of the KV cache");
+    k = k_.value();
+    v = v_.value();
+    TORCH_CHECK(k.dtype() == q_dtype, "Key must have the same dtype as query");
+    TORCH_CHECK(
+        v.dtype() == q_dtype, "Value must have the same dtype as query");
+    CHECK_DEVICE(k);
+    CHECK_DEVICE(v);
+    TORCH_CHECK(
+        k.stride(-1) == 1, "Key tensor must have contiguous last dimension");
+    TORCH_CHECK(
+        v.stride(-1) == 1, "Value tensor must have contiguous last dimension");
+    int seqlen_knew = k.size(1);
+    CHECK_SHAPE(k, batch_size, seqlen_knew, num_heads_k, head_size_og);
+    CHECK_SHAPE(v, batch_size, seqlen_knew, num_heads_k, head_size_og);
+    if (head_size_og % 8 != 0) {
+      k_padded = pad(k, {0, 8 - head_size_og % 8});
+      v_padded = pad(v, {0, 8 - head_size_og % 8});
+      // k_padded = at::nn::functional::pad(k,
+      // at::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
+      // v_padded = at::nn::functional::pad(v,
+      // at::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
+    } else {
+      k_padded = k;
+      v_padded = v;
+    }
+    params.seqlen_knew = seqlen_knew;
+    params.knew_ptr = k_padded.data_ptr();
+    params.vnew_ptr = v_padded.data_ptr();
+    // All stride are in elements, not bytes.
+    params.knew_batch_stride = k_padded.stride(0);
+    params.vnew_batch_stride = v_padded.stride(0);
+    params.knew_row_stride = k_padded.stride(-3);
+    params.vnew_row_stride = v_padded.stride(-3);
+    params.knew_head_stride = k_padded.stride(-2);
+    params.vnew_head_stride = v_padded.stride(-2);
+  }
+
+  if (seqlens_k_.has_value()) {
+    auto seqlens_k = seqlens_k_.value();
+    TORCH_CHECK(
+        seqlens_k.dtype() == c10::kInt, "seqlens_k must have dtype int32");
+    CHECK_DEVICE(seqlens_k);
+    CHECK_CONTIGUOUS(seqlens_k);
+    CHECK_SHAPE(seqlens_k, batch_size);
+    params.cu_seqlens_k = static_cast<int*>(seqlens_k.data_ptr());
+  }
+  params.is_seqlens_k_cumulative = !(seqlens_k_.has_value());
+
+  if (rotary_cos_.has_value()) {
+    TORCH_CHECK(
+        k_.has_value(),
+        "If rotary cos/sin are provided, new key / value to be appended to KV cache must also be provided");
+    auto rotary_cos = rotary_cos_.value();
+    CHECK_DEVICE(rotary_cos);
+    params.rotary_dim = rotary_cos.size(1) * 2;
+    TORCH_CHECK(
+        params.rotary_dim <= head_size, "rotary_dim must be <= headdim");
+    TORCH_CHECK(
+        params.rotary_dim % 16 == 0,
+        "Only rotary dimensions divisible by 16 are currently supported");
+    const int seqlen_ro = rotary_cos.size(0);
+    TORCH_CHECK(
+        seqlen_ro >= seqlen_k,
+        "cos/sin seqlen must be at least the seqlen of KV cache");
+    CHECK_SHAPE(rotary_cos, seqlen_ro, params.rotary_dim / 2);
+    CHECK_CONTIGUOUS(rotary_cos);
+    TORCH_CHECK(
+        rotary_cos.dtype() == q_dtype,
+        "rotary_cos must have the same dtype as query");
+
+    TORCH_CHECK(
+        rotary_sin_.has_value(),
+        "If rotary cos is provided, rotary sin must also be provided");
+    auto rotary_sin = rotary_sin_.value();
+    CHECK_DEVICE(rotary_sin);
+    CHECK_SHAPE(rotary_sin, seqlen_ro, params.rotary_dim / 2);
+    CHECK_CONTIGUOUS(rotary_sin);
+    TORCH_CHECK(
+        rotary_sin.dtype() == q_dtype,
+        "rotary_cos must have the same dtype as query");
+    params.rotary_cos_ptr = rotary_cos.data_ptr();
+    params.rotary_sin_ptr = rotary_sin.data_ptr();
+    params.is_rotary_interleaved = is_rotary_interleaved;
+  } else {
+    params.rotary_dim = 0;
+  }
+
+  if (cache_batch_idx_.has_value()) {
+    auto cache_batch_idx = cache_batch_idx_.value();
+    CHECK_DEVICE(cache_batch_idx);
+    CHECK_CONTIGUOUS(cache_batch_idx);
+    TORCH_CHECK(
+        cache_batch_idx.dtype() == c10::kInt,
+        "cache_batch_idx must have dtype int32");
+    params.cache_batch_idx = reinterpret_cast<int*>(cache_batch_idx.data_ptr());
+  }
+
+  // Keep references to these tensors to extend their lifetime
+  auto [softmax_lse_accum, out_accum] = set_params_splitkv(
+      params,
+      batch_size,
+      num_heads,
+      head_size,
+      seqlen_k,
+      seqlen_q,
+      head_size_rounded,
+      /*dropout*/ 0.f,
+      num_splits,
+      dprops,
+      opts);
+
+  if (paged_KV) {
+    params.block_table = static_cast<int*>(block_table.data_ptr());
+    params.block_table_batch_stride = block_table.stride(0);
+  }
+  params.page_block_size = page_block_size;
+
+  set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
+
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  // Only split kernel supports appending to KV cache, or indexing to the cache
+  // with cache_batch_idx, or paged KV cache
+  run_mha_fwd(
+      params,
+      stream,
+      /*force_split_kernel=*/k_.has_value() || cache_batch_idx_.has_value() ||
+          paged_KV);
+
+  if (head_size_og % 8 != 0) {
+    // out = out.index({"...", at::indexing::Slice(at::indexing::None,
+    // head_size_og)});
+    out = out.narrow(-1, 0, head_size_og);
+    if (out_.has_value()) {
+      out_.value().copy_(out);
+    }
+    if (k_.has_value()) {
+      // It's expensive to copy the KV cache here for the case where head size
+      // not divisible by 8, but we don't expect to get this case in practice.
+      // This is just so that the code works for that case.
+      const_cast<SlimTensor&>(kcache).copy_(
+          kcache_padded.narrow(-1, 0, head_size_og));
+      const_cast<SlimTensor&>(vcache).copy_(
+          vcache_padded.narrow(-1, 0, head_size_og));
+      // kcache.copy_(kcache_padded.index({"...",
+      // at::indexing::Slice(at::indexing::None, head_size_og)}));
+      // vcache.copy_(vcache_padded.index({"...",
+      // at::indexing::Slice(at::indexing::None, head_size_og)}));
+    }
+  }
+
+  if (seqlenq_ngroups_swapped) {
+    out = out.transpose(1, 2).reshape(
+        {batch_size, 1, num_heads_k * seqlen_q, head_size_og});
+    softmax_lse = softmax_lse.reshape({batch_size, num_heads_k * seqlen_q, 1});
+  }
+  return {out, softmax_lse};
+}

--- a/torch/csrc/inductor/aoti_standalone/cuda/flash_attn/flash_api.h
+++ b/torch/csrc/inductor/aoti_standalone/cuda/flash_attn/flash_api.h
@@ -1,0 +1,71 @@
+#pragma once
+#include <cstddef>
+#include <optional>
+#include <tuple>
+
+#include <c10/util/Exception.h>
+#include <torch/standalone/slim_tensor/slim_tensor.h>
+
+using torch::standalone::SlimTensor;
+
+std::tuple<
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor>
+mha_fwd(
+    const SlimTensor& q, // batch_size x seqlen_q x num_heads x head_size
+    const SlimTensor& k, // batch_size x seqlen_k x num_heads_k x head_size
+    const SlimTensor& v, // batch_size x seqlen_k x num_heads_k x head_size
+    std::optional<SlimTensor>&
+        out_, // batch_size x seqlen_q x num_heads x head_size
+    std::optional<SlimTensor>&
+        alibi_slopes_, // num_heads or batch_size x num_heads
+    const float p_dropout,
+    const float softmax_scale,
+    bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    const bool return_softmax);
+
+std::tuple<
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor,
+    SlimTensor>
+mha_varlen_fwd(
+    const SlimTensor&
+        q, // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+    const SlimTensor&
+        k, // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
+    const SlimTensor&
+        v, // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
+    std::optional<SlimTensor>&
+        out_, // total_q x num_heads x head_size, total_k := \sum_{i=0}^{b} s_i
+    const SlimTensor& cu_seqlens_q, // b+1
+    const SlimTensor& cu_seqlens_k, // b+1
+    std::optional<SlimTensor>&
+        seqused_k, // b. If given, only this many elements of each batch
+                   // element's keys are used.
+    std::optional<SlimTensor>&
+        block_table_, // batch_size x max_num_blocks_per_seq
+    std::optional<SlimTensor>& alibi_slopes_, // num_heads or b x num_heads
+    int max_seqlen_q,
+    const int max_seqlen_k,
+    const float p_dropout,
+    const float softmax_scale,
+    const bool zero_tensors,
+    bool is_causal,
+    int window_size_left,
+    int window_size_right,
+    const float softcap,
+    const bool return_softmax);

--- a/torch/csrc/inductor/aoti_standalone/cuda/flash_attn/static_switch.h
+++ b/torch/csrc/inductor/aoti_standalone/cuda/flash_attn/static_switch.h
@@ -1,0 +1,107 @@
+// Inspired by
+// https://github.com/NVIDIA/DALI/blob/main/include/dali/core/static_switch.h
+// and https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/Dispatch.h
+
+#pragma once
+
+/// @param COND       - a boolean expression to switch by
+/// @param CONST_NAME - a name given for the constexpr bool variable.
+/// @param ...       - code to execute for true and false
+///
+/// Usage:
+/// ```
+/// BOOL_SWITCH(flag, BoolConst, [&] {
+///     some_function<BoolConst>(...);
+/// });
+/// ```
+
+#define BOOL_SWITCH(COND, CONST_NAME, ...)      \
+  [&] {                                         \
+    if (COND) {                                 \
+      constexpr static bool CONST_NAME = true;  \
+      return __VA_ARGS__();                     \
+    } else {                                    \
+      constexpr static bool CONST_NAME = false; \
+      return __VA_ARGS__();                     \
+    }                                           \
+  }()
+
+#ifdef FLASHATTENTION_DISABLE_DROPOUT
+#define DROPOUT_SWITCH(COND, CONST_NAME, ...) \
+  [&] {                                       \
+    constexpr static bool CONST_NAME = false; \
+    return __VA_ARGS__();                     \
+  }()
+#else
+#define DROPOUT_SWITCH BOOL_SWITCH
+#endif
+
+#ifdef FLASHATTENTION_DISABLE_ALIBI
+#define ALIBI_SWITCH(COND, CONST_NAME, ...)   \
+  [&] {                                       \
+    constexpr static bool CONST_NAME = false; \
+    return __VA_ARGS__();                     \
+  }()
+#else
+#define ALIBI_SWITCH BOOL_SWITCH
+#endif
+
+#ifdef FLASHATTENTION_DISABLE_UNEVEN_K
+#define EVENK_SWITCH(COND, CONST_NAME, ...)  \
+  [&] {                                      \
+    constexpr static bool CONST_NAME = true; \
+    return __VA_ARGS__();                    \
+  }()
+#else
+#define EVENK_SWITCH BOOL_SWITCH
+#endif
+
+#ifdef FLASHATTENTION_DISABLE_LOCAL
+#define LOCAL_SWITCH(COND, CONST_NAME, ...)   \
+  [&] {                                       \
+    constexpr static bool CONST_NAME = false; \
+    return __VA_ARGS__();                     \
+  }()
+#else
+#define LOCAL_SWITCH BOOL_SWITCH
+#endif
+
+#define FP16_SWITCH(COND, ...)               \
+  [&] {                                      \
+    if (COND) {                              \
+      using elem_type = cutlass::half_t;     \
+      return __VA_ARGS__();                  \
+    } else {                                 \
+      using elem_type = cutlass::bfloat16_t; \
+      return __VA_ARGS__();                  \
+    }                                        \
+  }()
+
+#define HEADDIM_SWITCH(HEADDIM, ...)       \
+  [&] {                                    \
+    if (HEADDIM <= 32) {                   \
+      constexpr static int kHeadDim = 32;  \
+      return __VA_ARGS__();                \
+    } else if (HEADDIM <= 64) {            \
+      constexpr static int kHeadDim = 64;  \
+      return __VA_ARGS__();                \
+    } else if (HEADDIM <= 96) {            \
+      constexpr static int kHeadDim = 96;  \
+      return __VA_ARGS__();                \
+    } else if (HEADDIM <= 128) {           \
+      constexpr static int kHeadDim = 128; \
+      return __VA_ARGS__();                \
+    } else if (HEADDIM <= 160) {           \
+      constexpr static int kHeadDim = 160; \
+      return __VA_ARGS__();                \
+    } else if (HEADDIM <= 192) {           \
+      constexpr static int kHeadDim = 192; \
+      return __VA_ARGS__();                \
+    } else if (HEADDIM <= 224) {           \
+      constexpr static int kHeadDim = 224; \
+      return __VA_ARGS__();                \
+    } else if (HEADDIM <= 256) {           \
+      constexpr static int kHeadDim = 256; \
+      return __VA_ARGS__();                \
+    }                                      \
+  }()

--- a/torch/standalone/cuda/flash_attn_template.h
+++ b/torch/standalone/cuda/flash_attn_template.h
@@ -1,0 +1,211 @@
+#pragma once
+
+#include <cmath>
+#include <optional>
+#include <tuple>
+
+#include <torch/csrc/inductor/aoti_standalone/cuda/flash_attn/flash_api.h>
+
+namespace torch::standalone {
+
+// Forward declaration of _flash_attention_forward
+template <typename T>
+std::tuple<T, T, T, T, T> _flash_attention_forward(
+    const T& query,
+    const T& key,
+    const T& value,
+    const std::optional<T>& cumulative_sequence_length_q,
+    const std::optional<T>& cumulative_sequence_length_k,
+    int64_t max_seqlen_batch_q,
+    int64_t max_seqlen_batch_k,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    std::optional<double> scale,
+    std::optional<int64_t> window_size_left,
+    std::optional<int64_t> window_size_right,
+    const std::optional<T>& _seqused_k,
+    const std::optional<T>& _alibi_slopes);
+
+template <typename T>
+inline float calculate_scale(const T& query, std::optional<double> scale) {
+  return scale.has_value()
+      ? static_cast<float>(scale.value())
+      : static_cast<float>(
+            1.0 / std::sqrt(static_cast<double>(query.size(-1))));
+}
+
+template <typename T>
+std::tuple<T, T, T, T, int64_t, int64_t, T, T, T>
+_scaled_dot_product_flash_attention_cuda(
+    const T& query,
+    const T& key,
+    const T& value,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    std::optional<double> scale) {
+  const int64_t max_seqlen_batch_q = query.size(2);
+  const int64_t max_seqlen_batch_k = key.size(2);
+  const int64_t max_seqlen_batch_v = value.size(2);
+
+  TORCH_CHECK(
+      max_seqlen_batch_k == max_seqlen_batch_v,
+      "Key and Value must have the same sequence length");
+
+  // Query -> Query(Batch x Q_seq_len  x Num_heads x Dim_per_head)
+  // Key   -> Key  (Batch x KV_seq_len x Num_heads x Dim_per_head)
+  // Value -> Value(Batch x KV_seq_len x Num_heads x Dim_per_head)
+  T q_t = query.transpose(1, 2);
+  T k_t = key.transpose(1, 2);
+  T v_t = value.transpose(1, 2);
+
+  auto [output, logsumexp, philox_seed, philox_offset, debug_attn_mask] =
+      _flash_attention_forward<T>(
+          q_t,
+          k_t,
+          v_t,
+          std::optional<T>{},
+          std::optional<T>{},
+          max_seqlen_batch_q,
+          max_seqlen_batch_k,
+          dropout_p,
+          is_causal,
+          return_debug_mask,
+          scale,
+          std::nullopt,
+          std::nullopt,
+          std::optional<T>{},
+          std::optional<T>{});
+
+  T attention = output.transpose(1, 2);
+
+  auto cum_seq_q = create_empty_tensor({}, {}, query.dtype(), query.device());
+  auto cum_seq_k = create_empty_tensor({}, {}, key.dtype(), key.device());
+
+  return std::make_tuple(
+      std::move(attention),
+      std::move(logsumexp),
+      std::move(cum_seq_q),
+      std::move(cum_seq_k),
+      max_seqlen_batch_q,
+      max_seqlen_batch_k,
+      std::move(philox_seed),
+      std::move(philox_offset),
+      std::move(debug_attn_mask));
+}
+
+template <typename T>
+std::tuple<T, T, T, T, T> _flash_attention_forward(
+    const T& query,
+    const T& key,
+    const T& value,
+    const std::optional<T>& cumulative_sequence_length_q,
+    const std::optional<T>& cumulative_sequence_length_k,
+    int64_t max_seqlen_batch_q,
+    int64_t max_seqlen_batch_k,
+    double dropout_p,
+    bool is_causal,
+    bool return_debug_mask,
+    std::optional<double> scale,
+    std::optional<int64_t> window_size_left,
+    std::optional<int64_t> window_size_right,
+    const std::optional<T>& _seqused_k,
+    const std::optional<T>& _alibi_slopes) {
+  const auto softmax_scale = calculate_scale<T>(query, scale);
+
+  std::optional<T> out = std::nullopt;
+
+  std::optional<T> seqused_k = _seqused_k;
+  std::optional<T> block_table =
+      std::nullopt; // we are not using the block table yet
+  std::optional<T> alibi_slopes = _alibi_slopes;
+  const float softcap = 0.0;
+
+  const int64_t non_null_window_left =
+      window_size_left.has_value() ? *window_size_left : -1;
+  const int64_t non_null_window_right =
+      window_size_right.has_value() ? *window_size_right : -1;
+
+  TORCH_CHECK(
+      cumulative_sequence_length_q.has_value() ==
+          cumulative_sequence_length_k.has_value(),
+      "cumulative_sequence_length_q and cumulative_sequence_length_k must be both set or both not set");
+
+  T output = create_empty_tensor({}, {}, query.dtype(), query.device());
+  T q_padded = create_empty_tensor({}, {}, query.dtype(), query.device());
+  T k_padded = create_empty_tensor({}, {}, key.dtype(), key.device());
+  T v_padded = create_empty_tensor({}, {}, value.dtype(), value.device());
+  T logsumexp = create_empty_tensor({}, {}, query.dtype(), query.device());
+  T output_shape = create_empty_tensor({}, {}, query.dtype(), query.device());
+  T philox_seed = create_empty_tensor({}, {}, query.dtype(), query.device());
+  T philox_offset = create_empty_tensor({}, {}, query.dtype(), query.device());
+  T debug_attn_mask =
+      create_empty_tensor({}, {}, query.dtype(), query.device());
+
+  if (cumulative_sequence_length_q.has_value()) {
+    std::tie(
+        output,
+        q_padded,
+        k_padded,
+        v_padded,
+        logsumexp,
+        philox_seed,
+        philox_offset,
+        debug_attn_mask) =
+        mha_varlen_fwd(
+            query,
+            key,
+            value,
+            out,
+            cumulative_sequence_length_q.value(),
+            cumulative_sequence_length_k.value(),
+            seqused_k, /*seqused_k*/
+            block_table, /*block_table*/
+            alibi_slopes, /*alibi_slopes*/
+            max_seqlen_batch_q,
+            max_seqlen_batch_k,
+            dropout_p,
+            softmax_scale,
+            false /*zero_tensors*/,
+            is_causal,
+            non_null_window_left,
+            non_null_window_right,
+            softcap,
+            return_debug_mask);
+  } else {
+    std::tie(
+        output,
+        q_padded,
+        k_padded,
+        v_padded,
+        logsumexp,
+        philox_seed,
+        philox_offset,
+        debug_attn_mask) =
+        mha_fwd(
+            query,
+            key,
+            value,
+            out,
+            alibi_slopes,
+            dropout_p,
+            softmax_scale,
+            is_causal,
+            non_null_window_left,
+            non_null_window_right,
+            softcap,
+            return_debug_mask /*return_softmax (this is used for testing)*/);
+  }
+  debug_attn_mask = return_debug_mask
+      ? debug_attn_mask
+      : create_empty_tensor({}, {}, query.dtype(), query.device());
+  return std::make_tuple(
+      std::move(output),
+      std::move(logsumexp),
+      std::move(philox_seed),
+      std::move(philox_offset),
+      std::move(debug_attn_mask));
+}
+
+} // namespace torch::standalone


### PR DESCRIPTION
## Context
I am implementing standalone shim versions of all the necessary operators for running the Whisper Model libtorch-free, thereby eliminating the dependency on ATen. This PR is related with [scaled_dot_product_flash_attention](https://github.com/pytorch/pytorch/blob/cbe1cb70183dd0d08dd555353eeca72399401ae8/aten/src/ATen/native/transformers/cuda/attention.cu#L710) operator.

## Summary

The implementation of `scaled_dot_product_flash_attention` uses a third-party library `flash_api` and it is using `at::Tensor`'s and some other function from `at` namespace. And since we are trying to move away from aten, I also needed to replace them with SlimTensor, our shim functions that are previously implemented and some other functions from `c10`.

`flash_attention` takes a bit more time than the other operators because there was 2 important stage when implementing shim version of `scaled_dot_product_flash_attention`:

1) templatizing the flash_api
2) implementing `scaled_dot_product_flash_attention`

And I will be explaining more in details what I've done below.

## Implementation

**templatizing the flash_api:** 
As I've said above, it was using some other ops from aten, and we needed to implement them first in order to be able to make flash_api standalone.

- implemented shim version of [at::pad](https://github.com/pytorch/pytorch/blob/af9c92b4cb9f406129dfd8c64c082c0aaf7c723f/aten/src/ATen/native/PadNd.cpp#L247)
-[PR#11](https://github.com/desertfire/pytorch/pull/11)
- Updated `SlimTensor::fill_()` function since I designed it to only work for tensors with 1 elements (it used to be a scalar_fill). So I updated it to work in more general.
- Also updated the fast path of `SlimTensor::copy_()` function for it to also consider the offset for element size.
     - Without this, we wouldn't be able to perform a padding with negative values. 
- Implemented shim version of at::reshape. 
    - [PR#10](https://github.com/desertfire/pytorch/pull/10)
- Implemented shim version of `at::transpose`
    - [PR#8](https://github.com/desertfire/pytorch/pull/8) 


Yet even after implementing these operators, templatizing the `flash_api` to work both for at::Tensor and SlimTensor would not work since we won't have support for aten anymore. So I made it to work only for SlimTensor.

## Testing

4 tests written in total.

*   `CausalMaskNoDropout`: It tests standard causal attention for language modeling with a 4x8x512x64 tensor configuration (batch=4, heads=8, seq_len=512, head_dim=64) using causal masking and no dropout.
    
*   `NonCausalWithScale`: It tests non-causal attention (encoder-style) with different query/key-value sequence lengths (256 vs 128) and a custom scale factor of 0.125.
    
*   `CausalNonSquare`: It tests causal attention with non-square sequence lengths simulating text generation scenarios where a single new token (q_seq_len=1) attends to a long key/value cache (kv_seq_len=1024).
    
*   `NonCausalNonSquare`: It tests non-causal attention with non-square sequence lengths (q_seq_len=512, kv_seq_len=256) typical of encoder-decoder architectures where query and key/value sequences have different lengths.

```
(pytorch-3.12) [serhatgundem@devvm2480.eag0 /data/users/serhatgundem/pytorch_fork (implement_addmm_out)]$ ./build/bin/test_aoti_standa
lone  --gtest_filter=ScaledDotProductFlashAttentionTest.*
Only one CUDA device detected. Disabling MultiCUDA tests
Note: Google Test filter = ScaledDotProductFlashAttentionTest.*-*_MultiCUDA
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from ScaledDotProductFlashAttentionTest
[ RUN      ] ScaledDotProductFlashAttentionTest.CausalMaskNoDropout
[       OK ] ScaledDotProductFlashAttentionTest.CausalMaskNoDropout (393 ms)
[ RUN      ] ScaledDotProductFlashAttentionTest.NonCausalWithScale
[       OK ] ScaledDotProductFlashAttentionTest.NonCausalWithScale (221 ms)
[ RUN      ] ScaledDotProductFlashAttentionTest.CausalNonSquare
[       OK ] ScaledDotProductFlashAttentionTest.CausalNonSquare (12 ms)
[ RUN      ] ScaledDotProductFlashAttentionTest.NonCausalNonSquare
[       OK ] ScaledDotProductFlashAttentionTest.NonCausalNonSquare (210 ms)
[----------] 4 tests from ScaledDotProductFlashAttentionTest (838 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (838 ms total)
[  PASSED  ] 4 tests.
```

cc: @desertfire @angelayi @yushangdi
